### PR TITLE
per language API oversee by TSC

### DIFF
--- a/community-members.md
+++ b/community-members.md
@@ -1,6 +1,5 @@
 # The original list of maintainers
 
-
 ***This document is work in progress***
 
 This is an original list of maintainers to bootstrap the effort. Official docs
@@ -56,11 +55,31 @@ Maintainers:
 
 ## .NET
 
+Members:
+
+Approvers:
+
+Maintainers:
+
+- [Sergey Kanzhelev](https://github.com/SergeyKanzhelev), Microsoft
+
 ## Golang
+
+Approvers:
+
+- [Bogdan Drutu](https://github.com/BogdanDrutu), Google
 
 ## Node.js
 
+Approvers:
+
+- [Yuri Shkuro](https://github.com/yurishkuro), Uber
+
 ## Python
+
+Approvers:
+
+- [Carlos Alberto](https://github.com/carlosalberto), LightStep
 
 ## Agent and Collector
 


### PR DESCRIPTION
@bogdandrutu @carlosalberto @yurishkuro as discussed at morning meeting - I put our names as approvers on various languages to oversee APIs unification. Made myself maintainer for C# to not have a separate PR for this.