### PR TITLE
nominate maintainers for python

### DIFF
--- a/community-members.md
+++ b/community-members.md
@@ -62,6 +62,11 @@ Maintainers:
 
 ## Python
 
+Maintainers:
+
+- [Chris Kleinknecht](https://github.com/c24t), Google
+- [Reiley Yang](https://github.com/reyang), Microsoft
+
 ## Agent and Collector
 
 ## Others


### PR DESCRIPTION
@c24t, @reyang I'm nominating you as maintainers for OpenTelemetry Python SDK. Let me know if you  have issues with this.

Note, this is nomination, not a complete list.