### PR TITLE
Nominate Erlang maintainers

### DIFF
--- a/community-members.md
+++ b/community-members.md
@@ -108,7 +108,8 @@ Maintainers:
 ## Erlang
 
 Maintainers:
-- [Ilya Khaprov](https://github.com/deadtrickster), ???
+- [Ilya Khaprov](https://github.com/deadtrickster), KOBIL Systems
+- [Tristan Sloughter](https://github.com/tsloughter), Postmates Inc.
 
 ## Others
 

--- a/community-members.md
+++ b/community-members.md
@@ -105,6 +105,11 @@ Maintainers:
 - [Bogdan Drutu](https://github.com/BogdanDrutu), Google
 - [Paulo Janotti](https://github.com/pjanotti), Omnition
 
+## Erlang
+
+Maintainers:
+- [Ilya Khaprov](https://github.com/deadtrickster), ???
+
 ## Others
 
 C++, Erlang, PHP, Ruby, Rust, Swift


### PR DESCRIPTION
Based on OpenCensus work.

@deadtrickster please let me know if you OK with the nomination. Either like or comment on this PR. Also - your company affiliation if any.

Note, this is not a full list of maintainer, but a single person nomination