### PR TITLE
Nominate Carlos Alberto as Java Maintainer

### DIFF
--- a/community-members.md
+++ b/community-members.md
@@ -46,12 +46,11 @@ Members:
 
 Approvers:
 
-- [Carlos Alberto](https://github.com/carlosalberto), LightStep
 - [Pavol Loffay](https://github.com/pavolloffay), RedHat *appointed by Yuri*
 
 Maintainers:
-
 - [Bogdan Drutu](https://github.com/BogdanDrutu), Google
+- [Carlos Alberto](https://github.com/carlosalberto), LightStep
 
 ## .NET
 


### PR DESCRIPTION
Bumping from Approver to maintainer. Carlos is currently the primary maintainer of the OpenTracing Java API, and a TSC member.