### PR TITLE
Nominate Tyler Benson as a Java Approver

### DIFF
--- a/community-members.md
+++ b/community-members.md
@@ -40,6 +40,7 @@ Approvers:
 
 - [Pavol Loffay](https://github.com/pavolloffay), RedHat
 - [Yang Song](https://github.com/songy23), Google
+- [Tyler Benson](https://github.com/tylerbenson), DataDog
 
 Maintainers:
 - [Bogdan Drutu](https://github.com/BogdanDrutu), Google


### PR DESCRIPTION
@tylerbenson has been working in observability since ancient times, and has given the OpenTracing project a lot of helpful design feedback, especially in Java.