### PR TITLE
Propose an "Auto-Instrumentation SIG"

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ The Python SIG meets weekly on [Thursday 9 AM PDT](https://calendar.google.com/c
 
 You can also join us on [gitter](https://gitter.im/open-telemetry/opentelemetry-python).
 
+### Auto-Instrumentation (cross-language)
+
+"Auto-Instrumentation" refers to efforts to install OpenTelemetry instrumentation and otherwise extract OpenTelemetry-compatible data from processes without direct code modification. The Auto-Instrumentation SIG will meet weekly at a time TBD.
+
+You can also join us on [the auto-instrumentation channel](https://gitter.im/open-telemetry/auto-instrumentation) in OpenTelemetry gitter.
+
 ### Other
 
 We also considering creating SIGs for byte code injection agents and other projects.

--- a/community-members.md
+++ b/community-members.md
@@ -147,6 +147,16 @@ Approvers:
 Maintainers:
 - [Francis Bogsanyi](https://github.com/fbogsany), Shopify
 
-## Others
+## Other Languages
 
 C++, Erlang, PHP, Rust, Swift
+
+## Auto-Instrumentation
+
+Approvers:
+- [Ben Sigelman](https://github.com/bhs), LightStep
+
+Maintainers:
+- [Sergey Kanzhelev](https://github.com/SergeyKanzhelev), Microsoft
+- [Ted Young](https://github.com/tedsuo), LightStep
+


### PR DESCRIPTION
I know that @tedsuo and @SergeyKanzhelev are interested in this. Happy to seed the group with other folks as well.

I'm trying to avoid the word "Agent" since I know it has different meanings to different people. For what it's worth, the first order of business for the SIG would be to define the terms more crisply, but I'm basically imagining software that's linked in post-compilation and provides *portable* OpenTelemetry-compatible instrumentation; ideally in a clean, pluggable, well-factored manner, though all in due time. :)

Also, I'm happy to find a name other than "auto-instrumentation" as long as it's clear / unambiguous.