### PR TITLE
Make Python SIG 8AM

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ You can also join us on [gitter](https://gitter.im/open-telemetry/opentelemetry-
 
 ### Python SDK
 
-The Python SIG meets weekly on [Thursday 9 AM PDT](https://calendar.google.com/calendar/embed?src=google.com_346fplg7bemb44783pege5amj4%40group.calendar.google.com&ctz=America%2FLos_Angeles). This meeting is subject to change depending on contributors' availability, check the calendar for specific dates.
+The Python SIG meets weekly on [Thursday 8 AM PDT](https://calendar.google.com/calendar/embed?src=google.com_346fplg7bemb44783pege5amj4%40group.calendar.google.com&ctz=America%2FLos_Angeles). This meeting is subject to change depending on contributors' availability, check the calendar for specific dates.
 
 Meeting notes are held in this [doc](https://docs.google.com/document/d/1CIMGoIOZ-c3-igzbd6_Pnxx1SjAkjwqoYSUWxPY8XIs/edit).
 


### PR DESCRIPTION
Quick change to fix the time since it's 8AM on the calendar now.

We may switch this back to 9AM after the next meeting, but the README should be accurate in the meantime.