### PR TITLE
Nominating Tigran for specs approvers.

### DIFF
--- a/community-members.md
+++ b/community-members.md
@@ -30,6 +30,7 @@ Approvers:
 - [Yang Song](https://github.com/songy23), Google
 - [Chris Kleinknecht](https://github.com/c24t), Google
 - [Reiley Yang](https://github.com/reyang), Microsoft
+- [Tigran Najaryan](https://github.com/tigrannajaryan), Omnition
 
 Maintainers (TC - Technical committee):
 


### PR DESCRIPTION
Based on omnition contributions in OC and OT