### PR TITLE
Remove C++ & Erlang from others section as SIGs are formed

### DIFF
--- a/community-members.md
+++ b/community-members.md
@@ -169,4 +169,4 @@ Maintainers:
 
 ## Others
 
-C++, Erlang, PHP, Rust, Swift
+PHP, Rust, Swift


### PR DESCRIPTION
Just a minor edit -- SIGs for C++ and Erlang are formed already. I've removed those languages from "Others" section.