### PR TITLE
Fix conference dial-in info

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,9 +94,9 @@ Meeting notes are held in [this google doc](https://docs.google.com/document/d/1
 
 [Join Microsoft Teams Meeting](https://teams.microsoft.com/l/meetup-join/19%3ameeting_MTFkYzM5MTktOGQxMy00YTJkLWE1NmMtOTVjNTZlMmZkZGJj%40thread.v2/0?context=%7b%22Tid%22%3a%2272f988bf-86f1-41af-91ab-2d7cd011db47%22%2c%22Oid%22%3a%22faf2c66b-c829-47b3-832c-7112d576b360%22%7d)
 
-+1(469)480-6275, 21468028#   United States, Dallas (Toll)
++1(469)480-6275, 63411756#   United States, Dallas (Toll)
 
-+1(866)639-0588, 21468028#   United States (Toll-free)
++1(866)639-0588, 63411756#   United States (Toll-free)
 
 Conference ID: 634 117 56#
 


### PR DESCRIPTION
seems like this was copy-pasted from the .NET SIG info including its ID