### PR TITLE
Propose COMMUNICATION.md

### DIFF
--- a/COMMUNICATION.md
+++ b/COMMUNICATION.md
@@ -1,0 +1,21 @@
+# Communication within the OpenTelemetry Project
+
+## Document purpose
+
+OpenTelemetry has a [Code of Conduct](https://github.com/open-telemetry/community/blob/master/code-of-conduct.md) which primarily pertains to "bannable" offenses: things like harassment, personal attacks, and so on. Certainly OpenTelemetry does not tolerate any such behavior.
+
+And while we all deserve to collaborate without fear of overt harassment and personal attacks, that is a very low bar! This document is more aspirational and has fewer "teeth" (i.e., it's not about "banning" people), but it's also very important: it describes **how we wish to communicate with each other** and **how we aspire to create an environment that cultivates trust**, even in the face of inevitable technical and organizational disagreement.
+
+Finally, this is **a living document** and should be adapted over time as the OpenTelemetry project evolves. At any time, there are certainly errors of omissions or even simple clarifications we can make to the wording here, and any and all are welcome to propose such changes.
+
+Now, without further ado:
+
+## Communication guidelines
+
+What follows are an unordered list of principles that guide our communication with each other – both active community members as well as those who may just be "passing through" to file an issue or suggest an improvement.
+
+* **Critique ideas, not people:** It's fine and expected to disagree about technology and project direction. Even when those disagreements are significant or frustrating, though, it's not fine to criticize the participants. (In fact, it's usually a sign that there's no strong technical argument being made)
+* **Be welcoming:** By nature, OpenTelemetry touches a lot of other projects and will thus have a larger-than-normal ratio of casual committers and passers-by. For this reason, it's especially important to be welcoming to newcomers. This means thanking them for their interest and contributions, and being patient with their initial misunderstandings. In fact, their points of confusion are a valuable signal for documentation gaps.
+* **Try to keep conversations in the open:** Where possible, try to have conversations in async formats like GitHub issues, PRs, and emails. If resolution requires a call or videoconference, try to make a recording and notes available to keep our community accessible to other timezones.
+* **Strive for consensus, but don't require it:** Of course it's great when we can get everyone to agree. And certainly everyone should be – and should feel – heard. But once debate has died down and a decision must be made, it's best for the project and community to commit to that decision and make the best of it.
+


### PR DESCRIPTION
From the document itself:

>OpenTelemetry has a Code of Conduct which primarily pertains to "bannable" offenses: things like harassment, personal attacks, and so on. Certainly OpenTelemetry does not tolerate any such behavior.
>
>And while we all deserve to collaborate without fear of overt harassment and personal attacks, that is a very low bar! This document is more aspirational and has fewer "teeth" (i.e., it's not about "banning" people), but it's also very important: it describes how we wish to communicate with each other and how we aspire to create an environment that cultivates trust, even in the face of inevitable technical and organizational disagreement.

.....

Personally, I think the code of conduct is both super important and also pretty useless on a day-to-day level. I want something separate that we can reference in our conversations to promote optimal behavior and, potentially, to call out "suboptimal" behavior as needed.

Curious for other thoughts (on whether this doc should even exist, and what it should contain if we like the idea).