### PR TITLE
add Fred Hebert as an approver for Erlang lib

### DIFF
--- a/community-members.md
+++ b/community-members.md
@@ -147,6 +147,7 @@ Maintainers:
 Repo: [open-telemetry/opentelemetry-erlang](https://github.com/open-telemetry/opentelemetry-erlang)
 
 Approvers:
+- [Fred Hebert](https://github.com/ferd), Postmates Inc.
 
 Maintainers:
 - [Łukasz Jan Niemier](https://github.com/hauleth), 


### PR DESCRIPTION
The opentelemetry-erlang repo has only in the past month started having PRs for review, so the 3 months of reviewing requirement can not be met. But @ferd has given substantial reviews on our most recent PRs that are defining the structure of the project https://github.com/open-telemetry/opentelemetry-erlang/pulls

Fred in general is a good fit as an approver due to his experience with Erlang, both developing and teaching, plus writing 3 books on the subject:

- https://learnyousomeerlang.com/
- http://www.erlang-in-anger.com/
- http://propertesting.com/