### PR TITLE
Add Krzesimir Nowak as Go approver

### DIFF
--- a/community-members.md
+++ b/community-members.md
@@ -78,6 +78,7 @@ Approvers:
 - [Paulo Janotti](https://github.com/pjanotti), Omnition
 - [Steven Karis](https://github.com/sjkaris), Omnition
 - [Ted Young](https://github.com/tedsuo), LightStep
+- [Krzesimir Nowak](https://github.com/krnowak), Kinvolk
 
 Maintainers:
 


### PR DESCRIPTION
Krzesimir Nowak has made several substantial contributions to the OTel-Go repo, including the OpenTracing bridge. 

https://github.com/open-telemetry/opentelemetry-go/pull/98
https://github.com/opentracing/opentracing-go/pull/220

@krnowak 