### PR TITLE
Add Isobel Redelmeier as OTel-Go approver

### DIFF
--- a/community-members.md
+++ b/community-members.md
@@ -78,6 +78,7 @@ Approvers:
 - [Paulo Janotti](https://github.com/pjanotti), Omnition
 - [Steven Karis](https://github.com/sjkaris), Omnition
 - [Ted Young](https://github.com/tedsuo), LightStep
+- [Isobel Redelmeier](https://github.com/iredelmeier), LightStep
 
 Maintainers:
 


### PR DESCRIPTION
@iredelmeier is an [OTel-Go contributor](https://github.com/open-telemetry/opentelemetry-go/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Aclosed+author%3Airedelmeier), an OTel-Spec/Proto approver, and the author of https://github.com/lightstep/tracecontext.go, for example.