### PR TITLE
Add PHP SIG

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,14 @@ Meeting notes are held in a [Google doc](https://docs.google.com/document/d/18JV
 
 You can also join us on [gitter](https://gitter.im/open-telemetry/opentelemetry-erlang).
 
+### PHP SIG
+
+The PHP SIG meets weekly on [Wednesday 10:30 AM PDT](https://calendar.google.com/calendar/embed?src=google.com_346fplg7bemb44783pege5amj4%40group.calendar.google.com&ctz=America%2FLos_Angeles) via Zoom. Follow this link to [join the meeting](https://zoom.us/j/8203130519).
+
+Meeting notes are held in this [doc](https://docs.google.com/document/d/1WLDZGLY24rk5fRudjdQAcx_u81ZQWCF3zxiNT-sz7DI/edit).
+
+You can also join us on [gitter](https://gitter.im/open-telemetry/opentelemetry-php).
+
 ### Other
 
 We also considering creating SIGs for byte code injection agents and other projects.

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ You can also join us on [gitter](https://gitter.im/open-telemetry/opentelemetry-
 
 ### PHP SIG
 
-The PHP SIG meets weekly on [Wednesday 10:30 AM PDT](https://calendar.google.com/calendar/embed?src=google.com_346fplg7bemb44783pege5amj4%40group.calendar.google.com&ctz=America%2FLos_Angeles) via Zoom. Follow this link to [join the meeting](https://zoom.us/j/8203130519).
+The PHP SIG meets weekly on [Wednesday 10:30 AM PT](https://calendar.google.com/calendar/embed?src=google.com_346fplg7bemb44783pege5amj4%40group.calendar.google.com) via Zoom. Follow this link to [join the meeting](https://zoom.us/j/8203130519).
 
 Meeting notes are held in this [doc](https://docs.google.com/document/d/1WLDZGLY24rk5fRudjdQAcx_u81ZQWCF3zxiNT-sz7DI/edit).
 


### PR DESCRIPTION
Adds PHP SIG info to the community page. This assumes we can reuse the zoom meeting ID from the kick-off meeting.

cc @bobstrecansky 