### PR TITLE
Initial community members for PHP SIG

### DIFF
--- a/community-members.md
+++ b/community-members.md
@@ -181,6 +181,17 @@ Maintainers:
 - [Francis Bogsanyi](https://github.com/fbogsany), Shopify
 - [Matthew Wear](https://github.com/mwear), NewRelic
 
+## PHP
+
+Repo: [open-telemetry/opentelemetry-php](https://github.com/open-telemetry/opentelemetry-php)
+
+Approvers:
+- [Brain Akins](https://github.com/bakins), Mailchimp
+
+Maintainers:
+- [Bob Strecansky](https://github.com/bobstrecansky), Mailchimp
+- [Dmitry Krokhin](https://github.com/nekufa), basis.company
+
 ## Others
 
-PHP, Rust, Swift
+Rust, Swift


### PR DESCRIPTION
Based on discussion in the initial PHP SIG meeting, Bob Strecansky and Dmitry Krokhin have volunteered to maintain the repo, and Brain Akins has volunteered to review and approve code.

Since this is a bootstrapping operation, there are no prior commits or existing community members to point to.