### PR TITLE
Add Max and Reiley as the Approver and Maintainer for C++ SDK

### DIFF
--- a/community-members.md
+++ b/community-members.md
@@ -162,12 +162,14 @@ Maintainers:
 Repo: [open-telemetry/opentelemetry-cpp](https://github.com/open-telemetry/opentelemetry-cpp)
 
 Approvers:
+- [Max Golovanov](https://github.com/maxgolov), Microsoft
 - [Josh MacDonald](https://github.com/jmacd), LightStep
 - [Tigran Najaryan](https://github.com/tigrannajaryan), Splunk
 
 Maintainers:
-- [Ryan Burn](https://github.com/rnburn), LightStep
 - [Emil Mikulic](https://github.com/g-easy), Google
+- [Reiley Yang](https://github.com/reyang), Microsoft
+- [Ryan Burn](https://github.com/rnburn), LightStep
 
 ## Ruby
 


### PR DESCRIPTION
Currently there is no much activity in the C/C++ SDK.

@reyang has kicked off the initial C++ SDK community meeting, and will be driving this effort going forward. Reiley has been working on C++ compiler and debugger around 10 years ago.

@maxgolov is the current owner of the Microsoft internal C++ telemetry SDK, which is used across Azure/Office/Windows. He has wide experience working on embedded operating systems, drivers and low level stack.