### PR TITLE
Add Rahul Patel as approver for Collector

### DIFF
--- a/community-members.md
+++ b/community-members.md
@@ -124,6 +124,7 @@ Approvers:
 - [Steven Karis](https://github.com/sjkaris), Splunk
 - [Yang Song](https://github.com/songy23), Google
 - [Owais Lone](https://github.com/owais), Splunk
+- [Rahul Patel](https://github.com/rghetia), Google
 
 Maintainers:
 


### PR DESCRIPTION
Rahul has worked on the OpenCensus Service that served as basis for the Collector and is a maintainer on Go (same source language of the Collector). See #216 for his previous contributions.

Fixes #216

/cc @rghetia 