### PR TITLE
Add elswkid as Approver for Ruby

### DIFF
--- a/community-members.md
+++ b/community-members.md
@@ -178,6 +178,7 @@ Repo: [open-telemetry/opentelemetry-ruby](https://github.com/open-telemetry/open
 Approvers:
 - [Vlad Gorodetsky](https://github.com/bai), Shopify
 - [Yoshinori Kawasaki](https://github.com/luvtechno), Wantedly
+- [Don Morrison](https://github.com/elskwid), Mutations
 
 Maintainers:
 - [Francis Bogsanyi](https://github.com/fbogsany), Shopify


### PR DESCRIPTION
Don Morrison is an active contributor to the OpenTelemetry Ruby project, contributing 5 PRs to date. He'd like to start triaging issues for the project as well.