### PR TITLE
Add John Watson as approver for Java

### DIFF
--- a/community-members.md
+++ b/community-members.md
@@ -49,7 +49,7 @@ Approvers:
 - [Yang Song](https://github.com/songy23), Google
 - [Tyler Benson](https://github.com/tylerbenson), DataDog
 - [Armin Ruech](https://github.com/arminru), Dynatrace
-- [John Watson](https://github.com/jkwatson), New Relic
+- [John Watson](https://github.com/jkwatson), NewRelic
 
 Maintainers:
 - [Bogdan Drutu](https://github.com/BogdanDrutu), Google

--- a/community-members.md
+++ b/community-members.md
@@ -49,6 +49,7 @@ Approvers:
 - [Yang Song](https://github.com/songy23), Google
 - [Tyler Benson](https://github.com/tylerbenson), DataDog
 - [Armin Ruech](https://github.com/arminru), Dynatrace
+- [John Watson](https://github.com/jkwatson), New Relic
 
 Maintainers:
 - [Bogdan Drutu](https://github.com/BogdanDrutu), Google


### PR DESCRIPTION
John made a lot of contributions to the Java repo implementing a bunch of critical features like the name tracer, SpanData transition from proto, etc.

John also actively review a lot of PRs.