### PR TITLE
Nominating Mark Wolff as approver for JavaScript

### DIFF
--- a/community-members.md
+++ b/community-members.md
@@ -96,6 +96,7 @@ Approvers:
 - [Brandon Gonzalez](https://github.com/bg451), LightStep
 - [Olivier Albertini](https://github.com/OlivierAlbertini), VilledeMontreal
 - [Valentin Marchaud](https://github.com/vmarchaud), Open Source Contributor
+- [Mark Wolff](https://github.com/markwolff), Microsoft
 
 Maintainers:
 


### PR DESCRIPTION
Mark Wolff is an active contributor to the OpenTelemetry JavaScript project, implementing a bunch of important features like gRPC plugin, postgres plugin, global tracer, plugin loader etc.

Mark also actively review a lot of PRs and involved in SIG meetings.

/cc @markwolff @danielkhan 