### PR TITLE
Add Josh MacDonald as Specification approver

### DIFF
--- a/community-members.md
+++ b/community-members.md
@@ -31,6 +31,7 @@ Approvers:
 - [Chris Kleinknecht](https://github.com/c24t), Google
 - [Reiley Yang](https://github.com/reyang), Microsoft
 - [Tigran Najaryan](https://github.com/tigrannajaryan), Splunk
+- [Josh MacDonald](https://github.com/jmacd), LightStep
 
 Maintainers (TC - Technical committee):
 


### PR DESCRIPTION
Josh has done quite a bit of work, writing and approving specification requests. I would like to nominate him as a Specification approver.

History of spec work: https://github.com/open-telemetry/opentelemetry-specification/pulls?utf8=%E2%9C%93&q=jmacd+

I know we're switching SIGs to manage their own lists; raising this request here until that work is complete.
