### PR TITLE
Decentralize Ruby Maintainers and approvers list

### DIFF
--- a/community-members.md
+++ b/community-members.md
@@ -152,17 +152,7 @@ Maintainers:
 
 ## Ruby
 
-Repo: [open-telemetry/opentelemetry-ruby](https://github.com/open-telemetry/opentelemetry-ruby)
-
-Approvers:
-- [Vlad Gorodetsky](https://github.com/bai), Shopify
-- [Yoshinori Kawasaki](https://github.com/luvtechno), Wantedly
-- [Don Morrison](https://github.com/elskwid), Mutations
-
-Maintainers:
-- [Francis Bogsanyi](https://github.com/fbogsany), Shopify
-- [Matthew Wear](https://github.com/mwear), NewRelic
-- [Daniel Azuma](https://github.com/dazuma), Google
+The list of active members (both "approvers" and "maintainers") for OpenTelemetry Ruby can be found in the [open-telemetry/opentelemetry-ruby README file](https://github.com/open-telemetry/opentelemetry-ruby#contributing).
 
 ## PHP
 

--- a/community-members.md
+++ b/community-members.md
@@ -162,6 +162,7 @@ Approvers:
 Maintainers:
 - [Francis Bogsanyi](https://github.com/fbogsany), Shopify
 - [Matthew Wear](https://github.com/mwear), NewRelic
+- [Daniel Azuma](https://github.com/dazuma), Google
 
 ## PHP
 


### PR DESCRIPTION
@dazuma is the top contributor to OpenCensus Ruby and has been helping with infrastructure on OpenTelemetry Ruby. We'd be happy to have him as a maintainer.

See:
* https://github.com/census-instrumentation/opencensus-ruby/graphs/contributors
* https://github.com/census-instrumentation/opencensus-ruby/commits?author=dazuma
* https://github.com/open-telemetry/opentelemetry-ruby/pull/124
* https://github.com/open-telemetry/opentelemetry-ruby/pull/138