### PR TITLE
Approvers are now responsible for merging PRs.

### DIFF
--- a/community-membership.md
+++ b/community-membership.md
@@ -135,6 +135,7 @@ approver in the `CODEOWNER` files.
 - Expected to be responsive to review requests
 - Mentor contributors and reviewers
 - May approve code contributions for acceptance
+- Merge PRs that have recieved sufficient approval on behalf of those without permission to do so.
 
 ## Maintainer
 


### PR DESCRIPTION
This responsibility was absent from the guidelines, and
the lack of active merging can leave good changes stranded.

Giving approvers the responsibility as it ensures that
the requirement of an approver approving is enforced.

This was motivated by a conversation we had in opentelemetry-python, starting this PR as a conversation starter.

Addresses #71 