### PR TITLE
change approvers criterion as per governance committee meeting

### DIFF
--- a/community-members.md
+++ b/community-members.md
@@ -64,16 +64,7 @@ Find out active members - approvers and maintainers of .NET SDK in [open-telemet
 
 Repo: [open-telemetry/opentelemetry-go](https://github.com/open-telemetry/opentelemetry-go)
 
-Approvers:
-
-- [Paulo Janotti](https://github.com/pjanotti), Splunk
-- [Steven Karis](https://github.com/sjkaris), Splunk
-- [Ted Young](https://github.com/tedsuo), LightStep
-
-Maintainers:
-
-- [Rahul Patel](https://github.com/rghetia), Google
-- [Josh MacDonald](https://github.com/jmacd), LightStep
+The list of active members (both "approvers" and "maintainers") for the OpenTelemetry Go API and SDK can be found in the [open-telemetry/opentelemetry-go CONTRIBUTING file](https://github.com/open-telemetry/opentelemetry-go/blob/master/CONTRIBUTING.md#approvers-and-maintainers).
 
 ## JavaScript
 

--- a/governance-charter.md
+++ b/governance-charter.md
@@ -1,6 +1,6 @@
 # OpenTelemetry Governance Committee Charter
 
-Last update: 2019-12-19
+Last update: 10/28/2019
 
 ## Overview
 
@@ -109,9 +109,11 @@ vote in the elections, and may choose to run in the 2021 election).
 
 ### Members of Standing
 
-Standing in the OpenTelemetry community will be defined as the set of all
-members, approvers, and maintainers of the [OpenTelemetry
-organization](https://github.com/open-telemetry/community/blob/master/community-membership.md#member).
+Standing in the OpenTelemetry community will be defined by the union of:
+
+- Active members - those with 20 contributions (PRs, Issues, Comments etc.) in
+  the prior rolling year.
+- All approvers, and maintainers in the OpenTelemetry organization
 
 Members who don’t meet the criteria above and are part of the following are
 encouraged to help us evolve the definition of Member of Standing through the
@@ -130,7 +132,7 @@ criteria. Exception eligibility applications will be approved by the bootstrap
 committee by a simple majority vote. The exception process will be used as data
 points for refining the criteria for the future.
 
-The Governance Committee may periodically review and redefine these criteria
+Within its first year, the Governance Committee will redefine these criteria
 around a more robust idea of community membership.
 
 ### Eligibility for candidacy


### PR DESCRIPTION
Approvers criteria: make it easier to gain (and lose) approvership so that approvership more actively reflects the current set of trusted reviewers.

* Require approvers to be active at least once a month or else temporarily lose privileges (so we can trust `CODEOWNERS` to contain people who will actually be available to review pulls)
* Reduce requirement to 1 month and 10 non-trivial reviews, rather than 3 months and 30 reviews to become an approver, given our current state of maturity and length of time the project has existed.
* Explicitly specify that if an approver loses confidence of a maintainer, they can be removed from approvership, to address concerns that 1 month may be too speedy to permanently assess someone's technical judgment.