### PR TITLE
Revert "Sync CODEOWNERS to governance committeee"

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -12,4 +12,4 @@
 #  https://help.github.com/en/articles/about-code-owners
 #
 
-*  @bhs @bogdandrutu @sarahnovotny @SergeyKanzhelev @yurishkuro
+*  @bhs @bogdandrutu @sarahnovotny @SergeyKanzhelev @yurishkuro @lizthegrey @ccaraman @mtwo @tedsuo

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -12,4 +12,4 @@
 #  https://help.github.com/en/articles/about-code-owners
 #
 
-*  @opentelemetry/admins
+*  @bhs @bogdandrutu @sarahnovotny @SergeyKanzhelev @yurishkuro


### PR DESCRIPTION
Reverts open-telemetry/community#277 and goes back to individually tagging people.