### PR TITLE
Fix EEF Observability group link

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,4 +241,5 @@ Join W3C [Distributed Tracing Working Group](https://www.w3.org/2018/distributed
 
 ### Erlang Ecosystem Foundation – Observability Working Group
 
-See [Observability Working Group Proposal](https://erlef.org/observability-wg/).
+The Erlang and Elixir API and SDK are maintained by members of the Erlang Ecosystem Foundation Observability Working Group.
+See the [Observability Working Group](https://erlef.org/wg/observability) page on the EEF website for details.


### PR DESCRIPTION
I wanted to fix the link since it was broken, but figured it would also be nice to add a few words of description.