### PR TITLE
Remove and add new specs approvers

### DIFF
--- a/community-members.md
+++ b/community-members.md
@@ -26,8 +26,7 @@ Approvers:
 
 - [Ted Young](https://github.com/tedsuo), LightStep
 - [Isobel Redelmeier](https://github.com/iredelmeier), LightStep
-- [Alois Reitbauer](https://github.com/aloisReitbauer), Dynatrace
-- [Yang Song](https://github.com/songy23), Google
+- [Armin Ruech](https://github.com/arminru), Dynatrace
 - [Chris Kleinknecht](https://github.com/c24t), Google
 - [Reiley Yang](https://github.com/reyang), Microsoft
 - [Tigran Najaryan](https://github.com/tigrannajaryan), Splunk


### PR DESCRIPTION
* Remove @songy23 as he is no longer active in this project;
* Remove @AloisReitbauer as he is not active
* Add @arminru  to the specs approver list - @arminru had more than 30 PRs reviewed and is active since July, 2019.