### PR TITLE
Add entry for Log SIG

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,12 @@ Rust Gitter Channel: [![Gitter chat](https://badges.gitter.im/open-telemetry/ope
 
 Regular syncs take place every Thursday at 1:30 PM PT and are posted on the [calendar](https://github.com/open-telemetry/community#community-meetings). [Meeting notes](https://docs.google.com/document/d/1wW0jLldwXN8Nptq2xmgETGbGn9eWP8fitvD5njM-xZY) are updated every sync.
 
+### Log SIG
+
+Log SIG meets every other week on [TBD] via Zoom. Meeting notes are held in this [doc](https://docs.google.com/document/d/1cX5fWXyWqVVzYHSFUymYUfWxUK5hT97gc23w595LmdM/edit#).
+
+You can also join us on [gitter](https://gitter.im/open-telemetry/logs).
+
 ### Other
 
 We also considering creating SIGs for byte code injection agents and other projects.


### PR DESCRIPTION
Added the usual info about SIGs. Todo: add the regular meeting day/time
after we choose one.

Resolves: https://github.com/open-telemetry/community/issues/307