### PR TITLE
Clarify metrics and logging as part of spec SIG

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,22 @@ Dial by your location
 Meeting ID: 672 939 6170
 Find your local number: https://zoom.us/u/abrmtXWOh8
 
+#### Logs Sub-SIG
+
+The Logs sub-SIG of the specifiction SIG meets every other week on Wednesdays at alternating times via [Zoom](https://zoom.us/j/8203130519). Meeting notes are held in this [doc](https://docs.google.com/document/d/1cX5fWXyWqVVzYHSFUymYUfWxUK5hT97gc23w595LmdM/edit#).
+
+You can also join us on [gitter](https://gitter.im/open-telemetry/logs).
+
+#### Metrics Sub-SIG
+
+The Metrics sub-SIG of the specification SIG meets weekly on [Thursday 11 AM PDT](https://calendar.google.com/calendar/embed?src=google.com_b79e3e90j7bbsa2n2p5an5lf60%40group.calendar.google.com). This meeting is subject to change depending on contributors' availability, check the calendar for specific dates.
+
+Meeting notes are held in [this google doc](https://docs.google.com/document/d/1LfDVyBJlIewwm3a0JtDtEjkusZjzQE3IAix8b0Fxy3Y/edit).
+
+Link to join the [Zoom meeting](https://zoom.us/j/8203130519).
+
+You can also join us on [gitter](https://gitter.im/open-telemetry/metrics-specs).
+
 ### Agent/Collector
 
 The Service SIG meets every other week on [Wednesday at 9 AM PT](https://calendar.google.com/calendar/event?eid=Mmc5Z2w5anJncmFtNWFsOWVrZXVpc2RiaHRfMjAxOTA3MDNUMjEwMDAwWiBnb29nbGUuY29tX2I3OWUzZTkwajdiYnNhMm4ycDVhbjVsZjYwQGc&ctz=America/Los_Angeles).
@@ -234,22 +250,6 @@ Rust Gitter Channel: [![Gitter chat](https://badges.gitter.im/open-telemetry/ope
 ### Website SIG
 
 Regular syncs take place every Thursday at 1:30 PM PT and are posted on the [calendar](https://github.com/open-telemetry/community#community-meetings). [Meeting notes](https://docs.google.com/document/d/1wW0jLldwXN8Nptq2xmgETGbGn9eWP8fitvD5njM-xZY) are updated every sync.
-
-### Log SIG
-
-Log SIG meets every other week on [TBD] via Zoom. Meeting notes are held in this [doc](https://docs.google.com/document/d/1cX5fWXyWqVVzYHSFUymYUfWxUK5hT97gc23w595LmdM/edit#).
-
-You can also join us on [gitter](https://gitter.im/open-telemetry/logs).
-
-### Metrics SIG
-
-The Metrics SIG meets weekly on [Thursday 11 AM PDT](https://calendar.google.com/calendar/embed?src=google.com_b79e3e90j7bbsa2n2p5an5lf60%40group.calendar.google.com). This meeting is subject to change depending on contributors' availability, check the calendar for specific dates.
-
-Meeting notes are held in [this google doc](https://docs.google.com/document/d/1LfDVyBJlIewwm3a0JtDtEjkusZjzQE3IAix8b0Fxy3Y/edit).
-
-Link to join the [Zoom meeting](https://zoom.us/j/8203130519).
-
-You can also join us on [gitter](https://gitter.im/open-telemetry/metrics-specs).
 
 ### Other
 

--- a/README.md
+++ b/README.md
@@ -122,13 +122,13 @@ Dial by your location
 Meeting ID: 672 939 6170
 Find your local number: https://zoom.us/u/abrmtXWOh8
 
-#### Logs Sub-SIG
+#### Logs Working Group
 
 The Logs sub-SIG of the specifiction SIG meets every other week on Wednesdays at alternating times via [Zoom](https://zoom.us/j/8203130519). Meeting notes are held in this [doc](https://docs.google.com/document/d/1cX5fWXyWqVVzYHSFUymYUfWxUK5hT97gc23w595LmdM/edit#).
 
 You can also join us on [gitter](https://gitter.im/open-telemetry/logs).
 
-#### Metrics Sub-SIG
+#### Metrics Working Group
 
 The Metrics sub-SIG of the specification SIG meets weekly on [Thursday 11 AM PDT](https://calendar.google.com/calendar/embed?src=google.com_b79e3e90j7bbsa2n2p5an5lf60%40group.calendar.google.com). This meeting is subject to change depending on contributors' availability, check the calendar for specific dates.
 


### PR DESCRIPTION
Clarify that metrics and logging are workgroups under the specification SIG