### PR TITLE
Moving the PHP Community Members

### DIFF
--- a/community-members.md
+++ b/community-members.md
@@ -122,7 +122,7 @@ The list of active members (both "approvers" and "maintainers") for OpenTelemetr
 
 Repo: [open-telemetry/opentelemetry-php](https://github.com/open-telemetry/opentelemetry-php)
 
-The list of active members (both "approvers" and "maintainers") for the OpenTelemetry PHP API and SDK can be found in the [open-telemetry/opentelemetry-php CONTRIBUTING file](https://github.com/open-telemetry/opentelemetry-php/CONTRIBUTING.md).
+The list of active members (both "approvers" and "maintainers") for the OpenTelemetry PHP API and SDK can be found in the [open-telemetry/opentelemetry-php CONTRIBUTING file](https://github.com/open-telemetry/opentelemetry-php/blob/master/CONTRIBUTING.md).
 
 ## Others
 

--- a/community-members.md
+++ b/community-members.md
@@ -122,12 +122,7 @@ The list of active members (both "approvers" and "maintainers") for OpenTelemetr
 
 Repo: [open-telemetry/opentelemetry-php](https://github.com/open-telemetry/opentelemetry-php)
 
-Approvers:
-- [Brain Akins](https://github.com/bakins), Mailchimp
-
-Maintainers:
-- [Bob Strecansky](https://github.com/bobstrecansky), Mailchimp
-- [Dmitry Krokhin](https://github.com/nekufa), basis.company
+The list of active members (both "approvers" and "maintainers") for the OpenTelemetry PHP API and SDK can be found in the [open-telemetry/opentelemetry-php CONTRIBUTING file](https://github.com/open-telemetry/opentelemetry-php/CONTRIBUTING.md).
 
 ## Others
 


### PR DESCRIPTION
Moving our Approvers and Maintainers to be referenced in our repository.  I think I did this correctly (coinciding with https://github.com/open-telemetry/opentelemetry-php/pull/109) but I'd love for someone to double check my math!