### PR TITLE
Update Java Auto-Instrumentation SIG scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,9 +187,11 @@ Meeting notes are held in [this doc](https://docs.google.com/document/d/1oHpisis
 
 You can also join us on [gitter](https://gitter.im/open-telemetry/opentelemetry-java).
 
-#### Java Auto-Instrumentation
+#### Java Instrumentation
 
-Separate but related to the "Java SDK SIG", the "Java Auto-Instrumentation SIG" meets every [Thursday at 9 AM Pacific Time](https://calendar.google.com/calendar/embed?src=google.com_b79e3e90j7bbsa2n2p5an5lf60%40group.calendar.google.com). For more context, see [the auto-instrumentation OTEP](https://github.com/open-telemetry/oteps/blob/master/text/0001-telemetry-without-manual-instrumentation.md).
+Separate but related to the "Java SDK SIG", the "Java Instrumentation SIG" meets every [Thursday at 9 AM Pacific Time](https://calendar.google.com/calendar/embed?src=google.com_b79e3e90j7bbsa2n2p5an5lf60%40group.calendar.google.com). 
+
+The Java Instrumentation SIG covers both auto-instrumentation and (manual) instrumentation libraries.
 
 Meeting notes are held in this [doc](https://docs.google.com/document/d/1WK9h4p55p8ZjPkxO75-ApI9m0wfea6ENZmMoFRvXSCw/edit?usp=sharing).
 


### PR DESCRIPTION
In agreement with both the Java SIG and the Java Auto-Instrumentation SIG, we have expanded the scope of the Java Auto-Instrumentation SIG to also include (manual) library instrumentation (and we have renamed the opentelemetry-auto-instr-java repo to opentelemetry-java-instrumentation).

This should help us to better re-use code and tests across both auto-instrumentation and (manual) library instrumentation, and provide a consistent experience for users regardless of which approach they prefer.