### PR TITLE
Add .NET Auto-Instrumentation meetings

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,22 @@ Link to join the meeting: https://zoom.us/j/8203130519.
 
 You can also join us on [gitter](https://gitter.im/open-telemetry/opentelemetry-service).
 
+### .NET Auto-Instrumentation
+
+Regular sync up held weekly on Wednesdays at 4PM PT. Check
+the public OpenTelemetry calendar
+([web](https://calendar.google.com/calendar/embed?src=google.com_b79e3e90j7bbsa2n2p5an5lf60%40group.calendar.google.com),
+[gCal](https://calendar.google.com/calendar?cid=Z29vZ2xlLmNvbV9iNzllM2U5MGo3YmJzYTJuMnA1YW41bGY2MEBncm91cC5jYWxlbmRhci5nb29nbGUuY29t),
+[iCal](https://calendar.google.com/calendar/ical/google.com_b79e3e90j7bbsa2n2p5an5lf60%40group.calendar.google.com/public/basic.ics))
+for potential meeting time updates or cancellations.
+
+Meeting notes are held in [this google doc](https://docs.google.com/document/d/1XedN2D8_PH4YLej-maT8sp4RKogfuhFpccRi3QpUcoI/edit?usp=sharing).
+
+Link to join the meeting: https://zoom.us/j/8287234601.
+
+https://gitter.im/open-telemetry/opentelemetry-dotnet-auto-instr
+.NET Gitter Channel: [![Gitter chat](https://badges.gitter.im/open-telemetry/opentelemetry-dotnet.svg)](https://gitter.im/open-telemetry/opentelemetry-dotnet-auto-instr?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+
 ### .NET SDK
 
 Regular sync up held weekly on Tuesdays at alternating time - 11 AM PT and 4PM PT. Check


### PR DESCRIPTION
We've been piggy-backing on the .NET SDK, but starting on 08/05, we would hold a separate meeting.