### PR TITLE
Change .NET Auto-Instrumentation meeting time to 1 PM PT

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ You can also join us on [gitter](https://gitter.im/open-telemetry/opentelemetry-
 
 ### .NET Auto-Instrumentation
 
-Regular sync up held weekly on Wednesdays at 4PM PT. Check
+Regular sync up held weekly on Wednesdays at 1 PM PT. Check
 the public OpenTelemetry calendar
 ([web](https://calendar.google.com/calendar/embed?src=google.com_b79e3e90j7bbsa2n2p5an5lf60%40group.calendar.google.com),
 [gCal](https://calendar.google.com/calendar?cid=Z29vZ2xlLmNvbV9iNzllM2U5MGo3YmJzYTJuMnA1YW41bGY2MEBncm91cC5jYWxlbmRhci5nb29nbGUuY29t),


### PR DESCRIPTION
Updating the meeting time per discussion on Gitter: https://gitter.im/open-telemetry/opentelemetry-dotnet-auto-instr?at=5f31beccfe39ca5d65939ae8
