### PR TITLE
update python sig meeting time

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,8 +226,7 @@ You can also join us on [gitter](https://gitter.im/open-telemetry/opentelemetry-
 
 ### Python SDK
 
-The Python SIG meets weekly on Thursday, alternating between 9AM and 4PM PT.
-This meeting is subject to change depending on contributors' availability, check the [calendar](https://calendar.google.com/calendar/embed?src=google.com_b79e3e90j7bbsa2n2p5an5lf60%40group.calendar.google.com) for specific dates.
+The Python SIG meets weekly - every [Thursday at 9AM PT](https://calendar.google.com/calendar/embed?src=google.com_b79e3e90j7bbsa2n2p5an5lf60%40group.calendar.google.com).
 
 Meeting notes are held in this [doc](https://docs.google.com/document/d/1CIMGoIOZ-c3-igzbd6_Pnxx1SjAkjwqoYSUWxPY8XIs/edit).
 


### PR DESCRIPTION
The Python SIG decided to move the meetings back to a single time slot, 9am.