### PR TITLE
fix link to otel ruby

### DIFF
--- a/community-members.md
+++ b/community-members.md
@@ -120,7 +120,7 @@ The list of active members (both "approvers" and "maintainers") for OpenTelemetr
 
 ## Ruby
 
-Repo: [open-telemetry/opentelemetry-php](https://github.com/open-telemetry/opentelemetry-ruby)
+Repo: [open-telemetry/opentelemetry-ruby](https://github.com/open-telemetry/opentelemetry-ruby)
 
 The list of active members (both "approvers" and "maintainers") for OpenTelemetry Ruby can be found in the [open-telemetry/opentelemetry-ruby README file](https://github.com/open-telemetry/opentelemetry-ruby#contributing).
 


### PR DESCRIPTION
Changed link to say ruby instead of php.

Signed-off-by: Andrew Hsu <xuzuan@gmail.com>