### PR TITLE
#489 Added link to YoutTube recording of the GC

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ a friendly, collaborative group and look forward to working together!
 * [Governance Committee (GC)](./governance-charter.md)
 * [Technical Committee (TC)](./tech-committee-charter.md)
 
-Both committes meet regularly and the respective meeting notes are publicly available in the [GC meeting notes](https://docs.google.com/document/d/1-23Sf7-xZK3OL5Ogv2pK0NP9YotlSa0PKU9bvvtQwp8) and the [TC meeting notes](https://docs.google.com/document/d/17v2RMZlJZkgoPYHZhIFTVdDqQMIAH8kzo8Sl2kP3cbY) Google Docs.
+Both committes meet regularly and the respective meeting notes are publicly available in the [GC meeting notes](https://docs.google.com/document/d/1-23Sf7-xZK3OL5Ogv2pK0NP9YotlSa0PKU9bvvtQwp8) and the [TC meeting notes](https://docs.google.com/document/d/17v2RMZlJZkgoPYHZhIFTVdDqQMIAH8kzo8Sl2kP3cbY) Google Docs. If you want to check out the recordings, head to the [Governance Committee YouTube playlist](https://www.youtube.com/playlist?list=PLVYDBkQ1Tdyzg1CuQgd9mdjwOUYg7ECYR).
 
 ## Communication
 ### Instant Messaging


### PR DESCRIPTION
While doing this, I thought about updating the link in this paragraph:
"All meetings happen over Zoom, are recorded and available on YouTube, and have a meeting notes document."

To the https://www.youtube.com/channel/UCHZDBZTIfdy94xMjMKz-_MA/playlists one.  I'll check on the #489.