### PR TITLE
Update link to registration form

### DIFF
--- a/elections/2020/governance-committee-election.md
+++ b/elections/2020/governance-committee-election.md
@@ -115,7 +115,7 @@ One of two options will be available in the form to prove eligibility:
     dependency on OpenTelemetry, and/or your involvement with a well-known
     organization’s adoption of OpenTelemetry as an end-user.
 
-The link to the pre-registration form: [NEEDS UPDATE](https://github.com/open-telemetry/community/issues/488#issuecomment-700967483)
+The link to the pre-registration form: [OpenTelemetry 2020 Governance Committee Voter Registration Form](https://forms.gle/X4XjnJsVyNauEq9U7)
 
 Note that all pre-registrations will be verified by the Governance Committee
 for eligibility.


### PR DESCRIPTION
Updating docs with the correct link to the registration form so its easier for find. Right now link points to an issue, where you have to dig for the form again.