### PR TITLE
Clarify maintains' access to public calendar

### DIFF
--- a/community-membership.md
+++ b/community-membership.md
@@ -198,6 +198,8 @@ The following apply to the subproject for which one would be an owner.
 - Aligning with the overall project goals, specifications and design principles
   defined by Technical Committee (TC). Bringing general questions and requests
   to the discussions as part of specifications project.
+- Scheduling SIG meetings using the [OpenTelemetry Public
+  Calendar](./docs/how-to-handle-public-calendar.md).
 
 ### Responsibilities and privileges
 
@@ -206,7 +208,7 @@ The following apply to the subproject for which one would be an owner.
 - Make and approve technical design decisions for the subproject.
 - Set technical direction and priorities for the subproject.
 - Define milestones and releases.
-  - Decides on when PRs are merged to control the release scope. 
+  - Decides on when PRs are merged to control the release scope.
 - Mentor and guide approvers, reviewers, and contributors to the subproject.
 - Escalate *reviewer* and *maintainer* workflow concerns (i.e. responsiveness,
   availability, and general contributor community health) to the TC.

--- a/docs/how-to-handle-public-calendar.md
+++ b/docs/how-to-handle-public-calendar.md
@@ -31,5 +31,6 @@ Anyone can request to be added or removed as a meeting participant. Request can
 be made via GitHub issue on this repository or contacting SIG maintainer via
 other channels like Gitter.
 
-All SIG maintainers have permission to edit the Public OpenTelemetry calendar. 
-Please contact @mtwo via Gitter or by creating an issue if you require access.
+All SIG maintainers have permission to edit the Public OpenTelemetry calendar.
+Please contact @SergeyKanzhelev via Gitter or by creating an issue if you
+require access.


### PR DESCRIPTION
This was discussed during the Jan. 11th, 2021 maintainers meeting.

1. Clarified that maintainers can schedule/organize SIG meetings.
2. Clarified the process on how to get write access to public calendar. (not sure if @SergeyKanzhelev will replace @mtwo)

@SergeyKanzhelev @mtwo please confirm.