### PR TITLE
Minor update to the repo configuration guidelines

### DIFF
--- a/docs/how-to-configure-new-repository.md
+++ b/docs/how-to-configure-new-repository.md
@@ -30,7 +30,7 @@ for the repository.
    PRs. See the [Policies](#policies) section that suggest to ensure that `Require
    review from Code Owners` is checked.
 4. The team `foo-approvers` has `Write` permissions for the repository.
-5. The team `foo-maintainers` has `Maintain (beta)` permissions for the
+5. The team `foo-maintainers` has `Maintain` permissions for the
    repository.
 6. Root-level `CODEOWNERS` file on the repository should include superset of
    people from both `foo-approvers` and `foo-maintainers`.


### PR DESCRIPTION
The Maintain role is no longer in beta, see https://docs.github.com/en/github/setting-up-and-managing-organizations-and-teams/repository-permission-levels-for-an-organization.