### PR TITLE
Update Collector SIG meeting times

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ SIG-specific GitHub discussions.
 
 Name|Meeting Time|Meeting Notes|Meeting Link|Discussions|
 ----|------------|-------------|------------|------|
-Collector|Every Wednesday alternating between 09:00 and 14:00 PT|[Google Doc](https://docs.google.com/document/d/1r2JC5MB7GupCE7N32EwGEXs9V_YIsPgoFiLP4VWVMkE/edit?usp=sharing)|[Zoom](https://zoom.us/j/8203130519)|[Gitter](https://gitter.im/open-telemetry/opentelemetry-service)|
+Collector|Every Wednesday at 09:00 PT|[Google Doc](https://docs.google.com/document/d/1r2JC5MB7GupCE7N32EwGEXs9V_YIsPgoFiLP4VWVMkE/edit?usp=sharing)|[Zoom](https://zoom.us/j/8203130519)|[Gitter](https://gitter.im/open-telemetry/opentelemetry-service)|
 C/C++: SDK|Every week alternating between Monday at 15:00 PT and Wednesday at 10:00 PT|[Google Doc](https://docs.google.com/document/d/1i1E4-_y4uJ083lCutKGDhkpi3n4_e774SBLi9hPLocw/edit?usp=sharing)|[Zoom](https://zoom.us/j/8203130519)|[Gitter](https://gitter.im/open-telemetry/opentelemetry-cpp)|
 DotNET: Instrumentation|Every Wednesday at 13:00 PT|[Google Doc](https://docs.google.com/document/d/1XedN2D8_PH4YLej-maT8sp4RKogfuhFpccRi3QpUcoI/edit?usp=sharing)|[Zoom](https://zoom.us/j/8287234601)|[Gitter](https://gitter.im/open-telemetry/opentelemetry-dotnet-auto-instr)|
 DotNET: SDK|Every Tuesday alternating between 11:00 and 16:00 PT|[Google Doc](https://docs.google.com/document/d/1yjjD6aBcLxlRazYrawukDgrhZMObwHARJbB9glWdHj8/edit?usp=sharing)|[Zoom](https://zoom.us/j/8287234601)|[Gitter](https://gitter.im/open-telemetry/opentelemetry-dotnet)|


### PR DESCRIPTION
This was discussed a few times in the SIG meeting. We do not see much participation for the alternate time so changing to always have the meeting at the same time.