### PR TITLE
Add instructions for creating a new CNCF slack account

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Both committes meet regularly and the respective meeting notes are publicly avai
 ### Discussions
 We use [GitHub discussions](https://github.com/open-telemetry/community/discussions) for most communications. Please join us there!
 
-For those who are brand new to OpenTelemetry and just want to chat or get redirected to the appropriate place for a specific question, feel free to join [the CNCF OpenTelemetry Slack channel](https://cloud-native.slack.com/archives/CJFCJHG4Q).
+For those who are brand new to OpenTelemetry and just want to chat or get redirected to the appropriate place for a specific question, feel free to join [the CNCF OpenTelemetry Slack channel](https://cloud-native.slack.com/archives/CJFCJHG4Q). If you are new, you can create a CNCF Slack account [hare](http://slack.cncf.io/).
 
 ### Calendar
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Both committes meet regularly and the respective meeting notes are publicly avai
 ### Discussions
 We use [GitHub discussions](https://github.com/open-telemetry/community/discussions) for most communications. Please join us there!
 
-For those who are brand new to OpenTelemetry and just want to chat or get redirected to the appropriate place for a specific question, feel free to join [the CNCF OpenTelemetry Slack channel](https://cloud-native.slack.com/archives/CJFCJHG4Q). If you are new, you can create a CNCF Slack account [hare](http://slack.cncf.io/).
+For those who are brand new to OpenTelemetry and just want to chat or get redirected to the appropriate place for a specific question, feel free to join [the CNCF OpenTelemetry Slack channel](https://cloud-native.slack.com/archives/CJFCJHG4Q). If you are new, you can create a CNCF Slack account [here](http://slack.cncf.io/).
 
 ### Calendar
 


### PR DESCRIPTION
http://slack.cncf.io/ <-- new users need to go here first to create an account.