### PR TITLE
Update Gitter->Slack in community-membership requirement

### DIFF
--- a/community-membership.md
+++ b/community-membership.md
@@ -50,7 +50,8 @@ Defined by: Member of the OpenTelemetry GitHub organization
   - Filing or commenting on issues on GitHub
   - Contributing to SIGs, subprojects, or community discussions (e.g. meetings,
     chat, email, and discussion forums)
-- [Joined the gitter channel ](https://gitter.im/open-telemetry/community)
+- [Joined the Slack channel](https://cloud-native.slack.com/archives/CJFCJHG4Q)
+  - [Get an invite to join CNCF](http://slack.cncf.io/)
 - Have read the [contributor
   guide](https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md)
 - Actively contributing to 1 or more subprojects.


### PR DESCRIPTION
Removed the Gitter community link, and added links to get an invite and join the Slack community channel.