### PR TITLE
Add security and coverage scanning to best practices for new repos

### DIFF
--- a/docs/how-to-configure-new-repository.md
+++ b/docs/how-to-configure-new-repository.md
@@ -63,7 +63,10 @@ policies:
 
 ## Best practices
 
-It is recommended to set the following settings:
+It is recommended to follow these best practices:
 
 1. Only set "Allow squash merging" for the Merge button. It will ensure clean
    history for the repository.
+2. Set up a security scanning tool like, for example, [Github CodeQL](https://docs.github.com/en/code-security/secure-coding/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning).
+3. Set up a test coverage scanning tool like, for example, [Codecov](https://codecov.io/).
+4. Add status badges for passing builds and scans to the root README.


### PR DESCRIPTION
In https://github.com/open-telemetry/oteps/issues/144 and https://github.com/open-telemetry/opentelemetry-specification/issues/1333 CodeQL security scanning was enabled for most of our repositories and [most of them](https://codecov.io/gh/open-telemetry) already have Codecov coverage scanning set up. I think we should mention this in the new repo best practices so it's also considered right from the start when new repositories are created.