### PR TITLE
jsuereth was voted as a new TC member

### DIFF
--- a/community-members.md
+++ b/community-members.md
@@ -28,6 +28,7 @@ in alphabetical order:
 - [Bogdan Drutu](https://github.com/BogdanDrutu), Splunk
 - [Carlos Alberto](https://github.com/carlosalberto), Lightstep
 - [Josh MacDonald](https://github.com/jmacd), Lightstep
+- [Josh Suereth](https://github.com/jsuereth), Google
 - [Sergey Kanzhelev](https://github.com/SergeyKanzhelev), Google
 - [Tigran Najaryan](https://github.com/tigrannajaryan), Splunk
 - [Yuri Shkuro](https://github.com/yurishkuro), Facebook


### PR DESCRIPTION
Josh is active member of a community, who was working on various aspects of OpenTelemetry like metrics GA, stability or APIs and semantic conventions. The work included prototyping, writing specs and documents, and driving consensus on numerous meetings.

Technical Community voted unanimously to welcome Josh as a new TC member.

CC:
- @open-telemetry/technical-committee 
- @open-telemetry/governance-committee 
- @jsuereth 

Congratulations, Josh!