### PR TITLE
Reflect calendar / Zoom updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,33 +102,32 @@ from 3 largely distinct timezones. The best way to report it and suggest an
 alternative is to file an issue on this repository or discuss it in
 SIG-specific GitHub discussions.
 
-**Note: all meetings use the same passcode: _77777_**. This is embedded into all calendar Zoom links.
-
-Name|Meeting Time|Meeting Notes|Meeting Link|Discussions|
-----|------------|-------------|------------|------|
-Maintainers weekly meeting|Every Monday at 09:00PT|[Google Doc](https://docs.google.com/document/d/14lBtLAdzsV7M8xQNdhTJ0d2PxM1R7FByw-GttKJzVVw)|[Zoom](https://zoom.us/j/8287234601)|[Slack](https://cloud-native.slack.com/archives/C01NJ7V1KRC)|
-Collector|Every Wednesday at 09:00 PT|[Google Doc](https://docs.google.com/document/d/1r2JC5MB7GupCE7N32EwGEXs9V_YIsPgoFiLP4VWVMkE/edit?usp=sharing)|[Zoom](https://zoom.us/j/8203130519)|[Slack](https://cloud-native.slack.com/archives/C01N6P7KR6W)|
-C/C++: SDK|Every week alternating between Monday at 15:00 PT and Wednesday at 10:00 PT|[Google Doc](https://docs.google.com/document/d/1i1E4-_y4uJ083lCutKGDhkpi3n4_e774SBLi9hPLocw/edit?usp=sharing)|[Zoom](https://zoom.us/j/6729396170)|[Slack](https://cloud-native.slack.com/archives/C01N3AT62SJ)|
-DotNET: Instrumentation|Every Wednesday at 10:30 PT|[Google Doc](https://docs.google.com/document/d/1XedN2D8_PH4YLej-maT8sp4RKogfuhFpccRi3QpUcoI/edit?usp=sharing)|[Zoom](https://zoom.us/j/8203130519)|[Slack](https://cloud-native.slack.com/archives/C01NR1YLSE7)|
-DotNET: SDK|Every Tuesday alternating between 11:00 and 16:00 PT|[Google Doc](https://docs.google.com/document/d/1yjjD6aBcLxlRazYrawukDgrhZMObwHARJbB9glWdHj8/edit?usp=sharing)|[Zoom](https://zoom.us/j/8287234601)|[Slack](https://cloud-native.slack.com/archives/C01N3BC2W7Q)|
-Erlang/Elixir: SDK|Every Thursday alternating between 07:00 and 15:00 PT|[Google Doc](https://docs.google.com/document/d/1EbBiRjBc_cBf0T_B5OtNRPhbD4jdBrVYJAy8euCDrUI/edit?usp=sharing)|[Zoom](https://zoom.us/j/8287234601)|[Slack](https://cloud-native.slack.com/archives/C01N75YMZCN)|
-GoLang: SDK|Every Thursday alternating between 10:00 and 15:00 PDT|[Google Doc](https://docs.google.com/document/d/1A63zSWX0x2CyCK_LoNhmQC4rqhLpYXJzXbEPDUQ2n6w/edit#)|[Zoom](https://zoom.us/j/6729396170)|[Slack](https://cloud-native.slack.com/archives/C01NPAXACKT)|
-Instrumentation: General|Every Tuesday at 16:00 PT|[Google Doc](https://docs.google.com/document/d/1dWHhyXnfVife-cQ2DW5-d5Ldp1Lq8Rre2UsHpyo8cEE/)|[Zoom](https://zoom.us/j/6729396170?pwd=UFRIL0U0VzczUk1RK0hYaXJITXVldz09)|[Slack](https://cloud-native.slack.com/archives/C01QZFGMLQ7)
-Instrumentation: Messaging|Every Thursday at 8:00 PT|[Google Doc](https://docs.google.com/document/d/1dWHhyXnfVife-cQ2DW5-d5Ldp1Lq8Rre2UsHpyo8cEE/)|[Zoom](https://zoom.us/j/8203130519?pwd=elFSMWxOSVN0Qjk3cVJ1dzZoSnpnZz09)|[Slack](https://cloud-native.slack.com/archives/C01QZFGMLQ7)
-Java: SDK + Instrumentation|Every Thursday at 09:00 PT|[Google Doc](https://docs.google.com/document/d/1WK9h4p55p8ZjPkxO75-ApI9m0wfea6ENZmMoFRvXSCw/)|[Zoom](https://zoom.us/j/8203130519)|[SDK](https://cloud-native.slack.com/archives/C014L2KCTE3) and [Instrumentation](https://cloud-native.slack.com/archives/C0150QF88FL) Slack channels|
-JavaScript: SDK|Every Wednesday at 09:00 PT|[Google Doc](https://docs.google.com/document/d/1YR1Z3SqOkAJGffycO_P9d0CiTMP79OOtu_xvIyyVLME/edit?usp=sharing)|[Zoom](https://zoom.us/j/8287234601)|[GitHub Discussions](https://github.com/open-telemetry/opentelemetry-node/discussions)|
-PHP: SDK|Every Wednesday at 10:30 PT|[Google Doc](https://docs.google.com/document/d/1WLDZGLY24rk5fRudjdQAcx_u81ZQWCF3zxiNT-sz7DI/edit)|[Zoom](https://zoom.us/j/8287234601)|[Slack](https://cloud-native.slack.com/archives/C01NFPCV44V)|
-Python: SDK|Every Thursday at 09:00 PT|[Google Doc](https://docs.google.com/document/d/1CIMGoIOZ-c3-igzbd6_Pnxx1SjAkjwqoYSUWxPY8XIs/edit)|[Zoom](https://zoom.us/j/8287234601)|[Slack](https://cloud-native.slack.com/archives/C01PD4HUVBL)|
-Ruby: SIG|Every Tuesday at 09:00 PT|[Google Doc](https://docs.google.com/document/d/1D15bO8o340sQm2CVZiukEJuCO_XMMHKPuTznoEhyFqE/edit)|[Zoom](https://zoom.us/j/8287234601)|[GitHub Discussions](https://github.com/open-telemetry/opentelemetry-ruby/discussions)|
-Rust: SDK|Every other week on Tuesday alternating between 07:00 and 15:00 PT|[Google Doc](https://docs.google.com/document/d/1tGKuCsSnyT2McDncVJrMgg74_z8V06riWZa0Sr79I_4)|[Zoom](https://zoom.us/j/8203130519)|[Gitter](https://gitter.im/open-telemetry/opentelemetry-rust)|
-Specification: General|Every Tuesday at 08:00 PT|[Google Doc](https://docs.google.com/document/d/1pdvPeKjA8v8w_fGKAN68JjWBmVJtPCpqdi9IZrd6eEo/edit)|[Zoom](https://zoom.us/j/6729396170)|[Slack](https://cloud-native.slack.com/archives/C01N7PP1THC)
-Specification: Logs|Every week on Wednesday at 10:00 PT|[Google Doc](https://docs.google.com/document/d/1cX5fWXyWqVVzYHSFUymYUfWxUK5hT97gc23w595LmdM/edit#)|[Zoom](https://zoom.us/j/6729396170)|[Slack](https://cloud-native.slack.com/archives/C01N5UCHTEH)
-Specification: Metrics|Every Thursday alternating between 11:00 and 16:00 PT|[Google Doc](https://docs.google.com/document/d/1pdvPeKjA8v8w_fGKAN68JjWBmVJtPCpqdi9IZrd6eEo/edit)|[Zoom](https://zoom.us/j/8203130519)|[Slack](https://cloud-native.slack.com/archives/C01NP3BV26R)
-Specification: Sampling|Every Thursday at 08:00 PT|[Google Doc](https://docs.google.com/document/d/1gASMhmxNt9qCa8czEMheGlUW2xpORiYoD7dBD7aNtbQ/)|[Zoom](https://zoom.us/j/6729396170)||
-Swift: SDK|Every Thursday at 09:00 PT|[Google Doc](https://docs.google.com/document/d/1ShEFMywIV4LJcDYCNy41zkq8RR1sMq-tSvMBHngHcuk/edit?usp=sharing)|[Zoom](https://zoom.us/j/6729396170?pwd=UFRIL0U0VzczUk1RK0hYaXJITXVldz09)|[Slack](https://cloud-native.slack.com/archives/C01NCHR19SB)||
-Website|Every other week on Thursday at 13:30 ET|[Google Doc](https://docs.google.com/document/d/1wW0jLldwXN8Nptq2xmgETGbGn9eWP8fitvD5njM-xZY)|[Zoom](https://zoom.us/j/8203130519)||
-eBPF|Every week on Thursday at 10:30 PT|[Google Doc](https://docs.google.com/document/d/1pAxBekk6BadHpK717TbhYtBMOlyrgWSvp3QeYDPwwvk/edit?usp=sharing)|[Zoom](https://zoom.us/j/8287234601)|[Slack](https://cloud-native.slack.com/archives/C02AB15583A)|
-Agent Management WG|Every other week on Tuesday at 11:00 PT|[Google Doc](https://docs.google.com/document/d/1mHNnlCmO0XKUu0xPnKko3GOh0mxVoxjRiN8xmHRImew/edit#)|[Zoom](https://zoom.us/j/8203130519?pwd=elFSMWxOSVN0Qjk3cVJ1dzZoSnpnZz09)|[Slack](https://cloud-native.slack.com/archives/C02J58HR58R)|
+Name|Meeting Time|Meeting Notes|Discussions|
+----|------------|-------------|-----------|
+Maintainers weekly meeting|Every Monday at 09:00PT|[Google Doc](https://docs.google.com/document/d/14lBtLAdzsV7M8xQNdhTJ0d2PxM1R7FByw-GttKJzVVw)|[Slack](https://cloud-native.slack.com/archives/C01NJ7V1KRC)|
+Collector|Every Wednesday at 09:00 PT|[Google Doc](https://docs.google.com/document/d/1r2JC5MB7GupCE7N32EwGEXs9V_YIsPgoFiLP4VWVMkE/edit?usp=sharing)|[Slack](https://cloud-native.slack.com/archives/C01N6P7KR6W)|
+C/C++: SDK|Every week alternating between Monday at 15:00 PT and Wednesday at 10:00 PT|[Google Doc](https://docs.google.com/document/d/1i1E4-_y4uJ083lCutKGDhkpi3n4_e774SBLi9hPLocw/edit?usp=sharing)|[Slack](https://cloud-native.slack.com/archives/C01N3AT62SJ)|
+DotNET: Instrumentation|Every Wednesday at 10:30 PT|[Google Doc](https://docs.google.com/document/d/1XedN2D8_PH4YLej-maT8sp4RKogfuhFpccRi3QpUcoI/edit?usp=sharing)|[Slack](https://cloud-native.slack.com/archives/C01NR1YLSE7)|
+DotNET: SDK|Every Tuesday alternating between 11:00 and 16:00 PT|[Google Doc](https://docs.google.com/document/d/1yjjD6aBcLxlRazYrawukDgrhZMObwHARJbB9glWdHj8/edit?usp=sharing)|[Slack](https://cloud-native.slack.com/archives/C01N3BC2W7Q)|
+Erlang/Elixir: SDK|Every Thursday alternating between 07:00 and 15:00 PT|[Google Doc](https://docs.google.com/document/d/1EbBiRjBc_cBf0T_B5OtNRPhbD4jdBrVYJAy8euCDrUI/edit?usp=sharing)|[Slack](https://cloud-native.slack.com/archives/C01N75YMZCN)|
+GoLang: SDK|Every Thursday alternating between 10:00 and 15:00 PDT|[Google Doc](https://docs.google.com/document/d/1A63zSWX0x2CyCK_LoNhmQC4rqhLpYXJzXbEPDUQ2n6w/edit#)|[Slack](https://cloud-native.slack.com/archives/C01NPAXACKT)|
+Instrumentation: General|Every Tuesday at 16:00 PT|[Google Doc](https://docs.google.com/document/d/1dWHhyXnfVife-cQ2DW5-d5Ldp1Lq8Rre2UsHpyo8cEE/)|[Slack](https://cloud-native.slack.com/archives/C01QZFGMLQ7)
+Instrumentation: Messaging|Every Thursday at 8:00 PT|[Google Doc](https://docs.google.com/document/d/1dWHhyXnfVife-cQ2DW5-d5Ldp1Lq8Rre2UsHpyo8cEE/)|[Slack](https://cloud-native.slack.com/archives/C01QZFGMLQ7)
+Java: SDK + Instrumentation|Every Thursday at 09:00 PT|[Google Doc](https://docs.google.com/document/d/1WK9h4p55p8ZjPkxO75-ApI9m0wfea6ENZmMoFRvXSCw/)|[SDK](https://cloud-native.slack.com/archives/C014L2KCTE3) and [Instrumentation](https://cloud-native.slack.com/archives/C0150QF88FL) Slack channels|
+JavaScript: SDK|Every Wednesday at 09:00 PT|[Google Doc](https://docs.google.com/document/d/1YR1Z3SqOkAJGffycO_P9d0CiTMP79OOtu_xvIyyVLME/edit?usp=sharing)|[GitHub Discussions](https://github.com/open-telemetry/opentelemetry-node/discussions)|
+PHP: SDK|Every Wednesday at 10:30 PT|[Google Doc](https://docs.google.com/document/d/1WLDZGLY24rk5fRudjdQAcx_u81ZQWCF3zxiNT-sz7DI/edit)|[Slack](https://cloud-native.slack.com/archives/C01NFPCV44V)|
+Python: SDK|Every Thursday at 09:00 PT|[Google Doc](https://docs.google.com/document/d/1CIMGoIOZ-c3-igzbd6_Pnxx1SjAkjwqoYSUWxPY8XIs/edit)|[Slack](https://cloud-native.slack.com/archives/C01PD4HUVBL)|
+Ruby: SIG|Every Tuesday at 09:00 PT|[Google Doc](https://docs.google.com/document/d/1D15bO8o340sQm2CVZiukEJuCO_XMMHKPuTznoEhyFqE/edit)|[GitHub Discussions](https://github.com/open-telemetry/opentelemetry-ruby/discussions)|
+Rust: SDK|Every other week on Tuesday alternating between 07:00 and 15:00 PT|[Google Doc](https://docs.google.com/document/d/1tGKuCsSnyT2McDncVJrMgg74_z8V06riWZa0Sr79I_4)|[Gitter](https://gitter.im/open-telemetry/opentelemetry-rust)|
+Specification: General|Every Tuesday at 08:00 PT|[Google Doc](https://docs.google.com/document/d/1pdvPeKjA8v8w_fGKAN68JjWBmVJtPCpqdi9IZrd6eEo/edit)|[Slack](https://cloud-native.slack.com/archives/C01N7PP1THC)
+Specification: Logs|Every week on Wednesday at 10:00 PT|[Google Doc](https://docs.google.com/document/d/1cX5fWXyWqVVzYHSFUymYUfWxUK5hT97gc23w595LmdM/edit#)|[Slack](https://cloud-native.slack.com/archives/C01N5UCHTEH)
+Specification: Metrics|Every Thursday alternating between 11:00 and 16:00 PT|[Google Doc](https://docs.google.com/document/d/1pdvPeKjA8v8w_fGKAN68JjWBmVJtPCpqdi9IZrd6eEo/edit)|[Slack](https://cloud-native.slack.com/archives/C01NP3BV26R)
+Specification: Sampling|Every Thursday at 08:00 PT|[Google Doc](https://docs.google.com/document/d/1gASMhmxNt9qCa8czEMheGlUW2xpORiYoD7dBD7aNtbQ/)||
+Swift: SDK|Every Thursday at 09:00 PT|[Google Doc](https://docs.google.com/document/d/1ShEFMywIV4LJcDYCNy41zkq8RR1sMq-tSvMBHngHcuk/edit?usp=sharing)|[Slack](https://cloud-native.slack.com/archives/C01NCHR19SB)||
+Website|Every other week on Thursday at 13:30 ET|[Google Doc](https://docs.google.com/document/d/1wW0jLldwXN8Nptq2xmgETGbGn9eWP8fitvD5njM-xZY)||
+eBPF|Every week on Thursday at 10:30 PT|[Google Doc](https://docs.google.com/document/d/1pAxBekk6BadHpK717TbhYtBMOlyrgWSvp3QeYDPwwvk/edit?usp=sharing)|[Slack](https://cloud-native.slack.com/archives/C02AB15583A)|
+Agent Management WG|Every other week on Tuesday at 11:00 PT|[Google Doc](https://docs.google.com/document/d/1mHNnlCmO0XKUu0xPnKko3GOh0mxVoxjRiN8xmHRImew/edit#)|[Slack](https://cloud-native.slack.com/archives/C02J58HR58R)|
+Client Instrumentation|Every Wednesday at 9:00 AM PT|[Google Doc](https://docs.google.com/document/d/16Vsdh-DM72AfMg_FIt9yT9ExEWF4A_vRbQ3jRNBe09w/edit)|[Slack](https://cloud-native.slack.com/archives/C0239SYARD2)|
 
 ## Related groups
 

--- a/assets.md
+++ b/assets.md
@@ -36,6 +36,7 @@ This file is intended to list all the assets controlled by OpenTelemetry.
     - Members: SIG maintainers and individuals appointed by maintainers
 
 - [OpenTelemetry Calendar Invites Google Group](https://groups.google.com/g/opentelemetry-calendar)
+    - Used to automatically invite members to all OpenTelemetry calendar events, so that time is blocked on their calendars
     - Owners: @mtwo
 
 - Mailing list cncf-opentelemetry-net-maintainers@lists.cncf.io
@@ -64,6 +65,10 @@ This file is intended to list all the assets controlled by OpenTelemetry.
 - [Splain](https://splain.io/) account
     - Used to upload Zoom meeting recordings to Youtube
     - Owned by: Amye Scavarda Perrin (CNCF rep)
+
+- Project Google account: cncf-opentelemetry-governance@lists.cncf.io 
+    - Used to manage the OpenTelemetry community calendar and Zoom
+    - Owned by the governance committee
 
 ## Bot accounts
 

--- a/docs/how-to-handle-public-calendar.md
+++ b/docs/how-to-handle-public-calendar.md
@@ -1,24 +1,15 @@
 # How to create and configure meetings
 
-In OpenTelemetry we are using CNCF zoom account. We currently own four
-identical zoom accounts. The default room from every single account is
-used and a room can only host one meeting at a time. These are the
-account rooms:
-
-- https://zoom.us/j/6729396170
-- https://zoom.us/j/8203130519
-- https://zoom.us/j/8287234601
-- https://zoom.us/j/5227112777
-
-Meetings with the same room must not be held at the same time or be adjacent.
+In OpenTelemetry we are using the CNCF's Zoom accounts. We currently own four
+identical zoom accounts, though most meetings are created by the first account.
 
 All rooms are configured the same way. Some notes on meetings configuration:
 
-- **Host is not required** to join the meeting. Anybody can join the meeting.
+- **The host is not required** to join the meeting. Anybody can join the meeting.
 - **There is no time limit on the length of the meeting**. Please make sure nobody is
   using this room for another meeting on the calendar when meeting is going long
   over time.
-- **Auto-recording is enabled for all rooms**. All OpenTelemetry public meetings are being recorded automatically. Find recordings at [YouTube](https://www.youtube.com/channel/UCHZDBZTIfdy94xMjMKz-_MA).
+- **Auto-recording is enabled for all meetings**. All OpenTelemetry public meetings are being recorded automatically. Find recordings at [YouTube](https://www.youtube.com/channel/UCHZDBZTIfdy94xMjMKz-_MA).
 
 Every meeting must contain a link to the meeting notes. The meeting notes
 document must be shared with write or commenting permissions.
@@ -34,11 +25,13 @@ meetings can join the group.
 All SIG maintainers have permission to edit the Public OpenTelemetry calendar.
 To get access to the calendar, please join the Google Group opentelemetry-calendar-contributors@googlegroups.com by submitting a request [here](https://groups.google.com/g/opentelemetry-calendar-contributors).
 If your identity is not recognizable from the e-mail you are using to request joining the group, please
-request to be added to this Google Group by creating an issue in this repository.
+request to be added to this Google Group by creating an issue in this repository. To create a new meeting, you will need
+to either link one of the OpenTelemetry Zoom accounts to your public calendar, or you can use the credentials for the
+cncf-opentelemetry-governance@lists.cncf.io  Google account, which is already linked to one of the CNCF Zoom accounts.
 
 Please keep the membership of this group up to date and accurate.
 
 ## Zoom bombing prevention
-All meetings now require a passcode to join: _77777_. This passcode is embedded into the calendar meeting invites and meeting notes documents.
+All meetings are created by Zoom with randomized passcodes, which are embedded into the shared calendar links.
 All members of opentelemetry-calendar-contributors@googlegroups.com have access to [this document](https://docs.google.com/document/d/1gt9ctxKGPrM_XTINqLgkSxYypdrczHkt2znjwgBU4UU/edit#)
 listing the host keys for our meetings and explaining how to deal with inappropriate behavior in Zoom.


### PR DESCRIPTION
Updated our readme and documentation to reflect the recent improvements made to our calendar and Zoom links, which are now meeting-specific and are tied to a single CNCF Zoom account. Summary / justification:

I've updated all of our Zoom links in the calendar to use unique IDs. This has a few advantages:
- No more clashing meetings
- No more meetings from one SIG that unexpectedly flow into another SIG's call
- Meeting recordings should have titles now

There are some disadvantages:
- Meetings IDs and passwords are no longer predictable, meaning that meetings must be joined from the community calendar; I've removed static meeting links from the agenda docs and will remove them from GitHub
- Creating new meeting series will require access to the CNCF Zoom accounts

I made all of the edits through our new OpenTelemetry Google account, which is tied to the governance committee mailing list.