### PR TITLE
Make the TC responsible for adding new members

### DIFF
--- a/community-membership.md
+++ b/community-membership.md
@@ -103,7 +103,7 @@ the project, and are set by the project maintainers.
 
 Defined by: [Triage permissions](https://help.github.com/en/github/setting-up-and-managing-organizations-and-teams/repository-permission-levels-for-an-organization#repository-access-for-each-permission-level),
 with the names of the current Triagers commited to git, either in CONTRIBUTING,
-CODEOWNERS, or the botom of the README.
+CODEOWNERS, or the bottom of the README.
 
 Triagers may be code contributors, but writing code is not a requirement for
 becoming a triager. Triagers are encouraged to be active participants in project

--- a/community-membership.md
+++ b/community-membership.md
@@ -35,7 +35,7 @@ below.
 
 Members are continuously active contributors in the community. They can have
 issues and PRs assigned to them. Members are expected to participate in SIG or
-SIGs and remain active contributors to the community.  
+SIGs and remain active contributors to the community.
 
 Defined by: Member of the OpenTelemetry GitHub organization
 
@@ -71,10 +71,10 @@ Defined by: Member of the OpenTelemetry GitHub organization
     template](https://github.com/open-telemetry/community/blob/master/.github/ISSUE_TEMPLATE/membership.md))
   - Make sure that the list of contributions included is representative of your
     work on the project.
-- Have your sponsoring reviewers reply confirmation of sponsorship: `+1`
+- Have your sponsoring reviewers reply confirmation of sponsorship: `I support`
 - Once your sponsors have responded, your request will be reviewed by the
-  Governance Committee.  Any GC member can review the requirements and add
-  Members to the GitHub org. 
+  Technical Committee (TC).  Any TC member can review the requirements and add
+  Members to the GitHub org.
 
 ### Responsibilities and privileges
 
@@ -97,16 +97,16 @@ approver in addition to the reviews by *members.*
 
 ## Triager
 
-Triagers assist the maintainers and approvers with project management and 
-backlog organization. The specific workflows and triage requirements depend on 
+Triagers assist the maintainers and approvers with project management and
+backlog organization. The specific workflows and triage requirements depend on
 the project, and are set by the project maintainers.
 
-Defined by: [Triage permissions](https://help.github.com/en/github/setting-up-and-managing-organizations-and-teams/repository-permission-levels-for-an-organization#repository-access-for-each-permission-level), 
-with the names of the current Triagers commited to git, either in CONTRIBUTING, 
+Defined by: [Triage permissions](https://help.github.com/en/github/setting-up-and-managing-organizations-and-teams/repository-permission-levels-for-an-organization#repository-access-for-each-permission-level),
+with the names of the current Triagers commited to git, either in CONTRIBUTING,
 CODEOWNERS, or the botom of the README.
 
-Triagers may be code contributors, but writing code is not a requirement for 
-becoming a triager. Triagers are encouraged to be active participants in project 
+Triagers may be code contributors, but writing code is not a requirement for
+becoming a triager. Triagers are encouraged to be active participants in project
 meetings, chat rooms, and other discussion forums.
 
 ### Requirements


### PR DESCRIPTION
As this: https://github.com/open-telemetry/community/issues/921#issuecomment-978959069 reveals there is a mismatch of membership document and effective permissions.

By spirit, GC sets the rules of membership, and appoints who execute those rules. Since TC members are org admins, there are two ways to resolve this mismatch in membership document.

First option is to sponsor an automation that adds members and either automation or set of people appointed to check the membership requirements (company affiliation, approver+ status of sponsors). This is how [k8s is doing it](https://github.com/kubernetes/community/blob/master/community-membership.md#:~:text=once%20your%20sponsors%20have%20responded%2C%20your%20request%20will%20be%20reviewed%20by%20the%20kubernetes%20github%20admin%20team%2C%20in%20accordance%20with%20their%20slo.%20any%20missing%20information%20will%20be%20requested.):

> - Once your sponsors have responded, your request will be reviewed by the [Kubernetes GitHub Admin team], in accordance with their [SLO]. Any missing information will be requested.

Second option that is easier to implement is to change language to TC. This is what I sent in this PR.

I think long term to scale project better, GitHub admin team will be needed to handle this and other automation needs for the project. For now, change to TC may suffice.

CC: @open-telemetry/governance-committee  
CC: @open-telemetry/technical-committee  

