### PR TITLE
Add a process for becoming a maintainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Specification: Logs|Every week on Wednesday at 10:00 PT|[Google Doc](https://doc
 Specification: Metrics|Every Thursday alternating between 11:00 and 16:00 PT|[Google Doc](https://docs.google.com/document/d/1pdvPeKjA8v8w_fGKAN68JjWBmVJtPCpqdi9IZrd6eEo/edit)|[Slack](https://cloud-native.slack.com/archives/C01NP3BV26R)
 Specification: Sampling|Every Thursday at 08:00 PT|[Google Doc](https://docs.google.com/document/d/1gASMhmxNt9qCa8czEMheGlUW2xpORiYoD7dBD7aNtbQ/)||
 Swift: SDK|Every Thursday at 09:00 PT|[Google Doc](https://docs.google.com/document/d/1ShEFMywIV4LJcDYCNy41zkq8RR1sMq-tSvMBHngHcuk/edit?usp=sharing)|[Slack](https://cloud-native.slack.com/archives/C01NCHR19SB)||
-Website|Every other week on Thursday at 13:30 ET|[Google Doc](https://docs.google.com/document/d/1wW0jLldwXN8Nptq2xmgETGbGn9eWP8fitvD5njM-xZY)||
+Communications (Website, etc.)|Every other week on Thursday at 13:30 ET|[Google Doc](https://docs.google.com/document/d/1wW0jLldwXN8Nptq2xmgETGbGn9eWP8fitvD5njM-xZY)|[Slack](https://cloud-native.slack.com/archives/C02UN96HZH6)|
 eBPF|Every week on Thursday at 10:30 PT|[Google Doc](https://docs.google.com/document/d/1pAxBekk6BadHpK717TbhYtBMOlyrgWSvp3QeYDPwwvk/edit?usp=sharing)|[Slack](https://cloud-native.slack.com/archives/C02AB15583A)|
 Agent Management WG|Every other week on Tuesday at 11:00 PT|[Google Doc](https://docs.google.com/document/d/1mHNnlCmO0XKUu0xPnKko3GOh0mxVoxjRiN8xmHRImew/edit#)|[Slack](https://cloud-native.slack.com/archives/C02J58HR58R)|
 Client Instrumentation|Every Wednesday at 8:30 AM PT|[Google Doc](https://docs.google.com/document/d/16Vsdh-DM72AfMg_FIt9yT9ExEWF4A_vRbQ3jRNBe09w/edit)|[Slack](https://cloud-native.slack.com/archives/C0239SYARD2)|

--- a/community-membership.md
+++ b/community-membership.md
@@ -222,12 +222,16 @@ The following apply to the subproject for which one would be a maintainer.
 ### Becoming a Maintainer
 
 Unless stated otherwise in a SIG charter ratified by the Technical Committee,
-a new maintainer is elected by unanimous vote of the existing maintainers
-of the SIG. After a successful vote, a pull request should be made adding
-the new maintainer to the list of existing maintainers. Before the pull request
-is merged, all existing maintainers and the newly elected maintainer should
-approve the pull request to show their support for the public record. The
-nominee is considered a maintainer after the pull request is merged.
+a new maintainer is elected by vote of the existing maintainers of the SIG.
+The vote is officially started when a pull request to add a new maintainer
+is opened, and ends when the pull request is merged. The pull request may be
+merged when the following conditions are met:
+
+- The person being nominated has accepted the nomination by approving the pull request
+- All maintainers have approved the pull request OR a majority of maintainers
+  have approved the pull request and no maintainer has objected by requesting changes on the pull request
+
+The nominee is considered a maintainer after the pull request is merged.
 
 #### Self-nomination is encouraged
 

--- a/community-membership.md
+++ b/community-membership.md
@@ -180,10 +180,9 @@ files.
 
 ### Requirements
 
-The process for becoming a Maintainer should be defined in the SIG charter of
-the SIG owning the subproject. Unlike the roles outlined above, the Owners of a
-subproject are typically limited to a relatively small group of decision makers
-and updated as fits the needs of the subproject.
+Unlike the roles outlined above, the Owners of a subproject are typically
+limited to a relatively small group of decision makers and updated as fits
+the needs of the subproject.
 
 The following apply to the subproject for which one would be an owner.
 
@@ -219,6 +218,26 @@ The following apply to the subproject for which one would be an owner.
 - Ensure a healthy process for discussion and decision making is in place.
 - Work with other maintainers to maintain the project's overall health and
   success holistically.
+
+### Becoming a Maintainer
+
+Unless stated otherwise in a SIG charter ratified by the Technical Committee,
+a new maintainer is elected by unanimous vote of the existing maintainers
+of the SIG. After a successful vote, a pull request should be made adding
+the new maintainer to the list of existing maintainers. Before the pull request
+is merged, all existing maintainers and the newly elected maintainer should
+approve the pull request to show their support for the public record. The
+nominee is considered a maintainer after the pull request is merged.
+
+If you feel like you meet the requirements above and are willing to take on the
+additional responsibilities and privileges of being a maintainer, it is
+recommended that you approach an existing maintainer about sponsoring your bid
+to become a maintainer. After you and your sponsor have discussed the role
+and its additional requirements and responsibilities, they may approach the other
+maintainers about a vote to confirm you as a new maintainer. If the maintainer
+does not believe you are ready for the role, or the subproject is not in need
+of additional maintainers, they may suggest an alternate role or areas you can
+improve in order to improve your chances to become a maintainer in the future.
 
 ### Resolving technical conflicts within a SIG
 

--- a/community-membership.md
+++ b/community-membership.md
@@ -180,11 +180,11 @@ files.
 
 ### Requirements
 
-Unlike the roles outlined above, the Owners of a subproject are typically
+Unlike the roles outlined above, the maintainers of a subproject are typically
 limited to a relatively small group of decision makers and updated as fits
 the needs of the subproject.
 
-The following apply to the subproject for which one would be an owner.
+The following apply to the subproject for which one would be a maintainer.
 
 - Deep understanding of the technical goals and direction of the subproject
 - Deep understanding of the technical domain (specifically the language) of the
@@ -203,7 +203,7 @@ The following apply to the subproject for which one would be an owner.
 
 ### Responsibilities and privileges
 
-The following apply to the subproject for which one would be an owner.
+The following apply to the subproject for which one would be a maintainer.
 
 - Make and approve technical design decisions for the subproject.
 - Set technical direction and priorities for the subproject.

--- a/community-membership.md
+++ b/community-membership.md
@@ -229,7 +229,9 @@ merged when the following conditions are met:
 
 - The person being nominated has accepted the nomination by approving the pull request
 - All maintainers have approved the pull request OR a majority of maintainers
-  have approved the pull request and no maintainer has objected by requesting changes on the pull request
+  have approved the pull request and no maintainer has objected by requesting
+  changes on the pull request. In the case that all maintainers have not given
+  approval, the pull request should stay open for a minimum of 5 days before merging.
 
 The nominee is considered a maintainer after the pull request is merged.
 

--- a/community-membership.md
+++ b/community-membership.md
@@ -229,6 +229,8 @@ is merged, all existing maintainers and the newly elected maintainer should
 approve the pull request to show their support for the public record. The
 nominee is considered a maintainer after the pull request is merged.
 
+#### Self-nomination is encouraged
+
 If you feel like you meet the requirements above and are willing to take on the
 additional responsibilities and privileges of being a maintainer, it is
 recommended that you approach an existing maintainer about sponsoring your bid
@@ -236,8 +238,8 @@ to become a maintainer. After you and your sponsor have discussed the role
 and its additional requirements and responsibilities, they may approach the other
 maintainers about a vote to confirm you as a new maintainer. If the maintainer
 does not believe you are ready for the role, or the subproject is not in need
-of additional maintainers, they may suggest an alternate role or areas you can
-improve in order to improve your chances to become a maintainer in the future.
+of additional maintainers, they may suggest an alternate role or growth areas
+in order to improve your chances to become a maintainer in the future.
 
 ### Resolving technical conflicts within a SIG
 

--- a/governance-charter.md
+++ b/governance-charter.md
@@ -50,7 +50,7 @@ following:
 - **Delegate appropriate authority** to trusted individuals.
 
 This work is to be handled by the Governance Committee or delegated to other
-project groups like the Technical Committee (to be chartered by Fall 2019).
+project groups like the [Technical Committee](./tech-committee-charter.md).
 
 ## Committee Structure
 


### PR DESCRIPTION
As discussed last week, here is a draft of a process for electing new SIG maintainers.