### PR TITLE
Add Kubernetes operator SIG

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Communications (Website, etc.)|Every other week on Thursday at 13:30 ET|[Google 
 eBPF|Every week on Thursday at 10:30 PT|[Google Doc](https://docs.google.com/document/d/1pAxBekk6BadHpK717TbhYtBMOlyrgWSvp3QeYDPwwvk/edit?usp=sharing)|[Slack](https://cloud-native.slack.com/archives/C02AB15583A)|
 Agent Management WG|Every other week on Tuesday at 11:00 PT|[Google Doc](https://docs.google.com/document/d/1mHNnlCmO0XKUu0xPnKko3GOh0mxVoxjRiN8xmHRImew/edit#)|[Slack](https://cloud-native.slack.com/archives/C02J58HR58R)|
 Client Instrumentation|Every Wednesday at 8:30 AM PT|[Google Doc](https://docs.google.com/document/d/16Vsdh-DM72AfMg_FIt9yT9ExEWF4A_vRbQ3jRNBe09w/edit)|[Slack](https://cloud-native.slack.com/archives/C0239SYARD2)|
-Kubernetes Operator|TODO time|TODO google doc|https://cloud-native.slack.com/archives/C01N6P7KR6W|
+Kubernetes Operator|NA|https://docs.google.com/document/d/1zBNzh1dw9HpXUexTaURRS7n_NQSzqNJSuqNVw9GhIe4/edit#|https://cloud-native.slack.com/archives/C033BJ8BASU|
 
 ## Related groups
 

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Communications (Website, etc.)|Every other week on Thursday at 13:30 ET|[Google 
 eBPF|Every week on Thursday at 10:30 PT|[Google Doc](https://docs.google.com/document/d/1pAxBekk6BadHpK717TbhYtBMOlyrgWSvp3QeYDPwwvk/edit?usp=sharing)|[Slack](https://cloud-native.slack.com/archives/C02AB15583A)|
 Agent Management WG|Every other week on Tuesday at 11:00 PT|[Google Doc](https://docs.google.com/document/d/1mHNnlCmO0XKUu0xPnKko3GOh0mxVoxjRiN8xmHRImew/edit#)|[Slack](https://cloud-native.slack.com/archives/C02J58HR58R)|
 Client Instrumentation|Every Wednesday at 8:30 AM PT|[Google Doc](https://docs.google.com/document/d/16Vsdh-DM72AfMg_FIt9yT9ExEWF4A_vRbQ3jRNBe09w/edit)|[Slack](https://cloud-native.slack.com/archives/C0239SYARD2)|
-Operator|TODO time|TODO google doc|TODO slack|
+Kubernetes Operator|TODO time|TODO google doc|https://cloud-native.slack.com/archives/C01N6P7KR6W|
 
 ## Related groups
 

--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ Communications (Website, etc.)|Every other week on Thursday at 13:30 ET|[Google 
 eBPF|Every week on Thursday at 10:30 PT|[Google Doc](https://docs.google.com/document/d/1pAxBekk6BadHpK717TbhYtBMOlyrgWSvp3QeYDPwwvk/edit?usp=sharing)|[Slack](https://cloud-native.slack.com/archives/C02AB15583A)|
 Agent Management WG|Every other week on Tuesday at 11:00 PT|[Google Doc](https://docs.google.com/document/d/1mHNnlCmO0XKUu0xPnKko3GOh0mxVoxjRiN8xmHRImew/edit#)|[Slack](https://cloud-native.slack.com/archives/C02J58HR58R)|
 Client Instrumentation|Every Wednesday at 8:30 AM PT|[Google Doc](https://docs.google.com/document/d/16Vsdh-DM72AfMg_FIt9yT9ExEWF4A_vRbQ3jRNBe09w/edit)|[Slack](https://cloud-native.slack.com/archives/C0239SYARD2)|
+Operator|TODO time|TODO google doc|TODO slack|
 
 ## Related groups
 


### PR DESCRIPTION
Signed-off-by: Pavol Loffay <p.loffay@gmail.com>

Created based on https://cloud-native.slack.com/archives/C01N6P7KR6W/p1644395453360869

This PR adds Kubernetes operator SIG/WG. The purpose of the meeting is to discuss operator-related topics.

Given the operator community is not the largest the scope could be expanded to talk about everything Kubernetes deployment-related. For instance the scope could include opentelemetry-operator and opentelemetry-helm-charts. Right now there is already some level of integration between the operator and helm charts  (e.g. the helm chart that deploys the operator).

cc) @jpkrohling @VineethReddy02 @asuresh4 

