### PR TITLE
Add Daniel Jaglowski as log spec approver

### DIFF
--- a/community-members.md
+++ b/community-members.md
@@ -53,6 +53,7 @@ Metrics Approvers:
 Logs Approvers:
 
 - [Christian Beedgen](https://github.com/kumoroku), Sumo Logic
+- [Daniel Jaglowski](https://github.com/djaglowski), observIQ
 - [David Poncelow](https://github.com/zenmoto), Splunk
 
 Global Approvers:


### PR DESCRIPTION
Dan has been actively driving log spec changes for many months now.
The TC has reviewed the contributions and unanimously agreed that
Dan meets the requirements of the approver and can be a great log
spec approver.