### PR TITLE
Add Jack Berg as metrics spec approver

### DIFF
--- a/community-members.md
+++ b/community-members.md
@@ -45,6 +45,7 @@ Trace Approvers:
 
 Metrics Approvers:
 
+- [Jack Berg](https://github.com/jack-berg), New Relic
 - [Cijo Thomas](https://github.com/cijothomas), Microsoft
 - [John Watson](https://github.com/jkwatson), Splunk
 - [Leighton Chen](https://github.com/lzchen), Microsoft


### PR DESCRIPTION
Jack has been actively driving metrics spec changes and involved in the Java and Logs SIGs.

The TC has reviewed these contributions and unanimously agreed to accept Jack as a metrics specification approver.

Thank you @jack-berg!