### PR TITLE
Allow maintainers admin permissions on a case-by-case basis

### DIFF
--- a/docs/how-to-configure-new-repository.md
+++ b/docs/how-to-configure-new-repository.md
@@ -30,8 +30,10 @@ for the repository.
    PRs. See the [Policies](#policies) section that suggest to ensure that `Require
    review from Code Owners` is checked.
 4. The team `foo-approvers` has `Write` permissions for the repository.
-5. The team `foo-maintainers` has `Admin` permissions for the
+5. The team `foo-maintainers` has `Maintain` permissions for the
    repository.
+   In individual cases, for example, if this is required to allow maintainers to publish releases independently,
+   the team `foo-maintainers` can be granted `Admin` permissions instead.
 6. Root-level `CODEOWNERS` file on the repository should include superset of
    people from both `foo-approvers` and `foo-maintainers`.
 

--- a/docs/how-to-configure-new-repository.md
+++ b/docs/how-to-configure-new-repository.md
@@ -30,13 +30,10 @@ for the repository.
    PRs. See the [Policies](#policies) section that suggest to ensure that `Require
    review from Code Owners` is checked.
 4. The team `foo-approvers` has `Write` permissions for the repository.
-5. The team `foo-maintainers` has `Maintain` permissions for the
+5. The team `foo-maintainers` has `Admin` permissions for the
    repository.
 6. Root-level `CODEOWNERS` file on the repository should include superset of
    people from both `foo-approvers` and `foo-maintainers`.
-7. Some repositories may include more individuals with `Admin` permissions.
-   Typically to help set up repository, CI, web hooks or other administrative
-   work.
 
 ![image](https://user-images.githubusercontent.com/9950081/57563719-d7b6b300-7355-11e9-9ebb-3c4f549336bc.png)
 


### PR DESCRIPTION
In some cases, maintainers have admin permissions already. This officially allows that on a case-by-case basis.

The decision was made during the governance committee meeting on 2/17/2022 to temporarily grant admin permission to maintainers while the permissions differences between admin and maintain roles can be assessed. Currently, the rule is already inconsistently applied and many maintainers already have this permission and depend on it as part of their workflows. If it is determined that the maintain role is sufficient for maintainers, or that a custom role can be created, then it should be documented on an issue/PR and this can be updated then.

Related issues and PRs:
- Increase permission from `Write` to `Maintain` permission
	- Issue #84
	- PR #184
- Related discussion in #982

I would like approval from both @open-telemetry/governance-committee and @open-telemetry/technical-committee members for this PR, and would also appreciate the input of any maintainers.