### PR TITLE
Add reyang to the TC.

### DIFF
--- a/community-members.md
+++ b/community-members.md
@@ -27,6 +27,7 @@ in alphabetical order:
 - [Carlos Alberto](https://github.com/carlosalberto), Lightstep
 - [Josh MacDonald](https://github.com/jmacd), Lightstep
 - [Josh Suereth](https://github.com/jsuereth), Google
+- [Reiley Yang](https://github.com/reyang), Microsoft
 - [Sergey Kanzhelev](https://github.com/SergeyKanzhelev), Google
 - [Tigran Najaryan](https://github.com/tigrannajaryan), Splunk
 - [Yuri Shkuro](https://github.com/yurishkuro), Facebook


### PR DESCRIPTION
Reiley Yang has been an active member of the community, working on various aspects of OpenTelemetry, and lately helping drive metrics API/SDK stabilization.

The Technical Committee voted to welcome Reiley as a new TC member.

CC:

@open-telemetry/technical-committee
@open-telemetry/governance-committee 
@reyang 