### PR TITLE
Remove anuraaga from spec approvers

### DIFF
--- a/community-members.md
+++ b/community-members.md
@@ -60,7 +60,6 @@ Logs Approvers:
 
 Global Approvers:
 
-- [Anuraag Agrawal](https://github.com/anuraaga), AWS
 - [Josh Suereth](https://github.com/jsuereth), Google
 - [Reiley Yang](https://github.com/reyang), Microsoft
 


### PR DESCRIPTION
I had already left the GitHub team a while ago but forgot about this text. Mainly want to avoid being part of the triage flow

https://github.com/open-telemetry/opentelemetry-specification/blob/main/CONTRIBUTING.md#issue-triaging