### PR TITLE
Add Demo Application SIG to Community Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,9 @@ document](areas-of-interest.md) to help community members find
 interested parties and form new special interest groups.
 
 ## Communication
+
 ### Discussions
+
 We use [GitHub discussions](https://github.com/open-telemetry/community/discussions) for most communications. Please join us there!
 
 For those who are brand new to OpenTelemetry and want to chat or get redirected to the appropriate place for a specific question, feel free to join [the CNCF OpenTelemetry Slack channel](https://cloud-native.slack.com/archives/CJFCJHG4Q). If you are new, you can create a CNCF Slack account [here](http://slack.cncf.io/).

--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ eBPF|Every week on Thursday at 10:30 PT|[Google Doc](https://docs.google.com/doc
 Agent Management WG|Every other week on Tuesday at 11:00 PT|[Google Doc](https://docs.google.com/document/d/1mHNnlCmO0XKUu0xPnKko3GOh0mxVoxjRiN8xmHRImew/edit#)|[Slack](https://cloud-native.slack.com/archives/C02J58HR58R)|
 Client Instrumentation|Every Wednesday at 8:00 AM PT|[Google Doc](https://docs.google.com/document/d/16Vsdh-DM72AfMg_FIt9yT9ExEWF4A_vRbQ3jRNBe09w/edit)|[Slack](https://cloud-native.slack.com/archives/C0239SYARD2)|
 Kubernetes Operator|NA|[Google Doc](https://docs.google.com/document/d/1zBNzh1dw9HpXUexTaURRS7n_NQSzqNJSuqNVw9GhIe4/edit#)|[Slack](https://cloud-native.slack.com/archives/C033BJ8BASU)|
+Community Demo Application|Every Monday at 8:15 PT|[Google Doc](https://docs.google.com/document/d/16f-JOjKzLgWxULRxY8TmpM_FjlI1sthvKurnqFz9x98/edit)|[Slack](https://cloud-native.slack.com/archives/C03B4CWV4DA)|
 
 ## Related groups
 

--- a/community-members.md
+++ b/community-members.md
@@ -138,7 +138,6 @@ Repo: [open-telemetry/opentelemetry-cpp](https://github.com/open-telemetry/opent
 
 The list of active members (both "approvers" and "maintainers") for OpenTelemetry C++ can be found in the [open-telemetry/opentelemetry-cpp README file](https://github.com/open-telemetry/opentelemetry-cpp#contributing).
 
-
 ## Ruby
 
 Repo: [open-telemetry/opentelemetry-ruby](https://github.com/open-telemetry/opentelemetry-ruby)
@@ -150,6 +149,10 @@ The list of active members (both "approvers" and "maintainers") for OpenTelemetr
 Repo: [open-telemetry/opentelemetry-php](https://github.com/open-telemetry/opentelemetry-php)
 
 The list of active members (both "approvers" and "maintainers") for the OpenTelemetry PHP API and SDK can be found in the [open-telemetry/opentelemetry-php CONTRIBUTING file](https://github.com/open-telemetry/opentelemetry-php/blob/master/CONTRIBUTING.md).
+
+## Community Demo
+
+Placeholder for repo information
 
 ## Others
 

--- a/community-members.md
+++ b/community-members.md
@@ -152,7 +152,7 @@ The list of active members (both "approvers" and "maintainers") for the OpenTele
 
 ## Community Demo
 
-Placeholder for repo information
+Repo: [open-telemetry/opentelemetry-demo-webstore](https://github.com/open-telemetry/opentelemetry-demo-webstore)
 
 ## Others
 


### PR DESCRIPTION
Added Demo application SIG information to the community readme.md & added a repo placeholder 

Referencing this issue: https://github.com/open-telemetry/community/issues/1038