### PR TITLE
GitHub Action for publishing SIG meeting videos on YouTube

### DIFF
--- a/.github/workflows/youtube.yml
+++ b/.github/workflows/youtube.yml
@@ -1,3 +1,5 @@
+name: Publish Meetings on YouTube
+
 on:
   workflow_dispatch:
 

--- a/.github/workflows/youtube.yml
+++ b/.github/workflows/youtube.yml
@@ -1,0 +1,18 @@
+on:
+  workflow_dispatch:
+
+jobs:
+  publish_videos:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-dotnet@v2
+      with:
+        dotnet-version: 6.0.x
+    - env:
+        YOUTUBE_API_CLIENT_ID: ${{ secrets.YOUTUBE_API_CLIENT_ID }}
+        YOUTUBE_API_CLIENT_SECRET: ${{ secrets.YOUTUBE_API_CLIENT_SECRET }}
+        YOUTUBE_API_ACCESS_TOKEN: ${{ secrets.YOUTUBE_API_ACCESS_TOKEN }}
+        YOUTUBE_API_REFRESH_TOKEN: ${{ secrets.YOUTUBE_API_REFRESH_TOKEN }}
+      run: dotnet run
+      working-directory: ./tools/OpenTelemetryYoutube/OpenTelemetryYoutube

--- a/.github/workflows/youtube.yml
+++ b/.github/workflows/youtube.yml
@@ -1,6 +1,8 @@
 name: Publish Meetings on YouTube
 
 on:
+  schedule: 
+  - cron: 0 0/6 * * *
   workflow_dispatch:
 
 jobs:

--- a/tools/OpenTelemetryYoutube/OpenTelemetryYoutube/OpenTelemetryYoutube.csproj
+++ b/tools/OpenTelemetryYoutube/OpenTelemetryYoutube/OpenTelemetryYoutube.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tools/OpenTelemetryYoutube/OpenTelemetryYoutube/OpenTelemetryYoutube.csproj
+++ b/tools/OpenTelemetryYoutube/OpenTelemetryYoutube/OpenTelemetryYoutube.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Apis.Auth" Version="1.48.0" />
-    <PackageReference Include="Google.Apis.YouTube.v3" Version="1.47.0.2008" />
+    <PackageReference Include="Google.Apis.Auth" Version="1.57.0" />
+    <PackageReference Include="Google.Apis.YouTube.v3" Version="1.57.0.2715" />
   </ItemGroup>
 
 </Project>

--- a/tools/OpenTelemetryYoutube/OpenTelemetryYoutube/Program.cs
+++ b/tools/OpenTelemetryYoutube/OpenTelemetryYoutube/Program.cs
@@ -1,12 +1,7 @@
 ﻿using System;
-using System.IO;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using System.Xml;
-using Google.Apis.Auth.OAuth2;
-using Google.Apis.Services;
-using Google.Apis.Util.Store;
 using Google.Apis.YouTube.v3;
 using Google.Apis.YouTube.v3.Data;
 
@@ -25,13 +20,13 @@ namespace OpenTelemetryYoutube
         {
             try
             {
-                if (args.Length > 1)
+                if (args.Length == 1)
                 {
                     int.TryParse(args[1], out int minValue);
                     minValidVideoTime = minValue;
                 }
 
-                new Program().Run(args[0]).Wait();
+                new Program().Run().Wait();
             }
             catch (AggregateException ex)
             {
@@ -42,26 +37,9 @@ namespace OpenTelemetryYoutube
             }
         }
 
-        private async Task Run(string path)
+        private async Task Run()
         {
-            UserCredential credential;
-            using (var stream = new FileStream(path, FileMode.Open, FileAccess.Read))
-            {
-                credential = await GoogleWebAuthorizationBroker.AuthorizeAsync(
-                    GoogleClientSecrets.Load(stream).Secrets,
-                    new[] { YouTubeService.Scope.Youtube },
-                    "user",
-                    CancellationToken.None,
-                    new FileDataStore(this.GetType().ToString())
-                );
-            }
-
-            var youtubeService = new YouTubeService(new BaseClientService.Initializer
-            {
-                HttpClientInitializer = credential,
-                ApplicationName = this.GetType().ToString(),
-            });
-
+            var youtubeService = await YouTubeServiceHelper.Instance.GetYouTubeService();
             var channelsListRequest = youtubeService.Channels.List("snippet,contentDetails,statistics");
             channelsListRequest.Mine = true;
 

--- a/tools/OpenTelemetryYoutube/OpenTelemetryYoutube/Program.cs
+++ b/tools/OpenTelemetryYoutube/OpenTelemetryYoutube/Program.cs
@@ -112,7 +112,7 @@ namespace OpenTelemetryYoutube
                     Snippet = new VideoSnippet
                     {
                         CategoryId = "22",
-                        Title = $"{videoItem.Snippet.PublishedAt.Split('T')[0]} meeting",
+                        Title = $"{videoItem.Snippet.PublishedAt:yyyy-MM-dd} meeting",
                         Description = string.IsNullOrEmpty(videoItem.Snippet.Description)
                             ? $"{videoItem.Snippet.Title}"
                             : $"OriginalTitle={videoItem.Snippet.Title};OriginalDescription={videoItem.Snippet.Description}",
@@ -134,7 +134,7 @@ namespace OpenTelemetryYoutube
                     Snippet = new VideoSnippet
                     {
                         CategoryId = "22",
-                        Title = $"{videoItem.Snippet.PublishedAt.Split('T')[0]} {videoItem.Snippet.Title}"
+                        Title = $"{videoItem.Snippet.PublishedAt:yyyy-MM-dd} {videoItem.Snippet.Title}"
                     },
                     Status = new VideoStatus
                     {

--- a/tools/OpenTelemetryYoutube/OpenTelemetryYoutube/Program.cs
+++ b/tools/OpenTelemetryYoutube/OpenTelemetryYoutube/Program.cs
@@ -132,7 +132,10 @@ namespace OpenTelemetryYoutube
                     Snippet = new VideoSnippet
                     {
                         CategoryId = "22",
-                        Title = $"{videoItem.Snippet.PublishedAt.Split('T')[0]} meeting"
+                        Title = $"{videoItem.Snippet.PublishedAt.Split('T')[0]} meeting",
+                        Description = string.IsNullOrEmpty(videoItem.Snippet.Description)
+                            ? $"{videoItem.Snippet.Title}"
+                            : $"OriginalTitle={videoItem.Snippet.Title};OriginalDescription={videoItem.Snippet.Description}",
                     },
                     Status = new VideoStatus
                     {

--- a/tools/OpenTelemetryYoutube/OpenTelemetryYoutube/Program.cs
+++ b/tools/OpenTelemetryYoutube/OpenTelemetryYoutube/Program.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Xml;
@@ -34,6 +34,8 @@ namespace OpenTelemetryYoutube
                 {
                     Console.WriteLine("Error: " + e.Message);
                 }
+
+                Environment.Exit(1);
             }
         }
 

--- a/tools/OpenTelemetryYoutube/OpenTelemetryYoutube/Program.cs
+++ b/tools/OpenTelemetryYoutube/OpenTelemetryYoutube/Program.cs
@@ -123,7 +123,7 @@ namespace OpenTelemetryYoutube
             // that we know that the video already been processed. 202x = 2020, 2021, etc.
             // video that doesn't start with 202x and has totalMinutes > 30, we will process
             if (!videoItem.Snippet.Title.StartsWith("202")
-                && time.TotalMinutes > 20
+                && time.TotalMinutes > 10
                 && !videoItem.Snippet.Title.StartsWith(governanceCommitteeVideoName, StringComparison.OrdinalIgnoreCase))
             {
                 video = new Video

--- a/tools/OpenTelemetryYoutube/OpenTelemetryYoutube/YouTubeServiceHelper.cs
+++ b/tools/OpenTelemetryYoutube/OpenTelemetryYoutube/YouTubeServiceHelper.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Google.Apis.Auth.OAuth2;
+using Google.Apis.Auth.OAuth2.Responses;
+using Google.Apis.Services;
+using Google.Apis.YouTube.v3;
+
+namespace OpenTelemetryYoutube;
+
+internal class YouTubeServiceHelper
+{
+    private YouTubeServiceHelper()
+    {
+        this.ClientId = Environment.GetEnvironmentVariable("YOUTUBE_API_CLIENT_ID");
+        this.ClientSecret = Environment.GetEnvironmentVariable("YOUTUBE_API_CLIENT_SECRET");
+        this.AccessToken = Environment.GetEnvironmentVariable("YOUTUBE_API_ACCESS_TOKEN");
+        this.RefreshToken = Environment.GetEnvironmentVariable("YOUTUBE_API_REFRESH_TOKEN");
+    }
+
+    public static YouTubeServiceHelper Instance { get; } = new YouTubeServiceHelper();
+
+    public string ClientId { get; }
+    public string ClientSecret { get; }
+    public string AccessToken { get; }
+    public string RefreshToken { get; }
+
+    public TokenResponse GetTokenResponse()
+    {
+        return new TokenResponse
+        {
+            AccessToken = this.AccessToken,
+            ExpiresInSeconds = 3599,
+            RefreshToken = this.RefreshToken,
+            Scope = "https://www.googleapis.com/auth/youtube",
+            TokenType = "Bearer",
+            IssuedUtc = System.DateTime.UtcNow,
+        };
+    }
+
+    public async Task<YouTubeService> GetYouTubeService()
+    {
+        var credential = await GoogleWebAuthorizationBroker.AuthorizeAsync(
+            new ClientSecrets
+            {
+                ClientId = this.ClientId,
+                ClientSecret = this.ClientSecret,
+            },
+            new[] { YouTubeService.Scope.Youtube },
+            "user",
+            CancellationToken.None,
+            new YouTubeToolDataStore()
+        );
+
+        return new YouTubeService(new BaseClientService.Initializer
+        {
+            HttpClientInitializer = credential,
+            ApplicationName = typeof(Program).ToString(),
+        });
+    }
+}

--- a/tools/OpenTelemetryYoutube/OpenTelemetryYoutube/YouTubeToolDataStore.cs
+++ b/tools/OpenTelemetryYoutube/OpenTelemetryYoutube/YouTubeToolDataStore.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Threading.Tasks;
+using Google.Apis.Util.Store;
+
+namespace OpenTelemetryYoutube;
+
+internal class YouTubeToolDataStore : IDataStore
+{
+    public Task ClearAsync()
+    {
+        return Task.FromResult(0);
+    }
+
+    public Task DeleteAsync<T>(string key)
+    {
+        return Task.FromResult(0);
+    }
+
+    public Task<T> GetAsync<T>(string key)
+    {
+        if (string.IsNullOrEmpty(key))
+        {
+            throw new ArgumentException("Key MUST have a value");
+        }
+
+        TaskCompletionSource<T> tcs = new TaskCompletionSource<T>();
+        if (YouTubeServiceHelper.Instance.GetTokenResponse() is T tokenResponse)
+        {
+            tcs.SetResult(tokenResponse);
+        }
+        else
+        {
+            throw new ArgumentException($"Type '{typeof(T)}' unsupported");
+        }
+
+        return tcs.Task;
+    }
+
+    public Task StoreAsync<T>(string key, T value)
+    {
+        return Task.FromResult(0);
+    }
+}

--- a/tools/OpenTelemetryYoutube/README.md
+++ b/tools/OpenTelemetryYoutube/README.md
@@ -5,7 +5,13 @@
 * [dotnet](https://dotnet.microsoft.com/download) installed to run
   the application
 * Your user need to be manager or owner of the channel
-* OAuth credentials from [Google Console](https://console.developers.google.com/)
+* Configure access to use the [YouTube Data API](https://developers.google.com/youtube/v3/getting-started).
+  Steps are roughly as follows:
+  1. Create a project using the [Google Developers Console](https://console.developers.google.com/).
+  2. From the [Enabled APIs page](https://console.developers.google.com/apis/enabled)
+     make sure the YouTube Data API v3 is enabled for the project.
+  3. Create OAuth credentials from the [Credentials page](https://console.cloud.google.com/apis/credentials).
+  4. Configure the consent screen from the [OAuth consent screen page](https://console.cloud.google.com/apis/credentials/consent).
 
 ## Configuration
 
@@ -15,6 +21,47 @@ Running the tool requires the following environment variables to be set:
 * `YOUTUBE_API_CLIENT_SECRET`
 * `YOUTUBE_API_ACCESS_TOKEN`
 * `YOUTUBE_API_REFRESH_TOKEN`
+
+The `YOUTUBE_API_CLIENT_ID` and `YOUTUBE_API_CLIENT_SECRET` variables should be
+set with the appropriate values from the OAuth credentials created when
+configuring access to the [YouTube Data API](https://developers.google.com/youtube/v3/getting-started).
+
+Generate an access and refresh token as follows:
+
+1. The following command works on a Mac and opens a browswer window
+   facilitating the generation of an authorization code:
+
+    ```shell
+    open "https://accounts.google.com/o/oauth2/auth?client_id=$YOUTUBE_API_CLIENT_ID&redirect_uri=urn:ietf:wg:oauth:2.0:oob&scope=https://www.googleapis.com/auth/youtube&response_type=code"
+    ```
+
+2. Run the following curl command using the authorization code generated in the
+   previous step:
+
+    ```shell
+    curl \
+    -d "client_id=$YOUTUBE_API_CLIENT_ID" \
+    -d "client_secret=$YOUTUBE_API_CLIENT_SECRET" \
+    -d "redirect_uri=urn:ietf:wg:oauth:2.0:oob" \
+    -d "grant_type=authorization_code" \
+    -d "code=PUT_AUTH_CODE_FROM_STEP_1_HERE" \
+    https://accounts.google.com/o/oauth2/token
+    ```
+
+    Sample response:
+
+    ```json
+    {
+      "access_token": "YOUR_ACCESS_TOKEN",
+      "expires_in": 3599,
+      "refresh_token": "YOUR_REFRESH_TOKEN",
+      "scope": "https://www.googleapis.com/auth/youtube",
+      "token_type": "Bearer"
+    }
+    ```
+
+3. Set the `YOUTUBE_API_ACCESS_TOKEN` and `YOUTUBE_API_REFRESH_TOKEN`
+   environment variables to the values retreived in the previous step.
 
 ## How to use
 

--- a/tools/OpenTelemetryYoutube/README.md
+++ b/tools/OpenTelemetryYoutube/README.md
@@ -2,25 +2,31 @@
 
 ## Pre-requisites
 
-* [dotnet](https://dotnet.microsoft.com/download/dotnet-core) installed to run
+* [dotnet](https://dotnet.microsoft.com/download) installed to run
   the application
-* `secret.json` from [Google Console](https://console.developers.google.com/)
 * Your user need to be manager or owner of the channel
+* OAuth credentials from [Google Console](https://console.developers.google.com/)
+
+## Configuration
+
+Running the tool requires the following environment variables to be set:
+
+* `YOUTUBE_API_CLIENT_ID`
+* `YOUTUBE_API_CLIENT_SECRET`
+* `YOUTUBE_API_ACCESS_TOKEN`
+* `YOUTUBE_API_REFRESH_TOKEN`
 
 ## How to use
 
-1. Create your OAuth credential at [Google
-   Console](https://console.developers.google.com/)
-2. Download the `secret.json`
-3. Build and run the application:
+Build and run the application:
 
 * `dotnet build`
-* `dotnet run path_to_secrets.json`
+* `dotnet run`
 
 This will filter the total video duration to be deleted (if time less then 5
 minutes, it will automatically delete):
 
-* `dotnet run path_to_secrets.json 5`
+* `dotnet run 5`
 
 ## What it does
 


### PR DESCRIPTION
Fixes #863 

Here it is folks. I've been running this action from my own fork of the community repo for months now.

I've modified the tool to retrieve its configuration from a set of environment variables. The values of these variables need to be stored as secrets on the repo.

The OAuth credentials required for using the YouTube API is kinda a pain as they require a Google account and they expire periodically. There may be some options to get around this. At this point it probably just makes sense for me to meet with one of the maintainers to figure out the best way to proceed.

In the meantime, this tool is running happily on my fork every 6 hours.