### PR TITLE
Remove John Watson from Metrics Approvers

### DIFF
--- a/community-members.md
+++ b/community-members.md
@@ -48,7 +48,6 @@ Metrics Approvers:
 
 - [Jack Berg](https://github.com/jack-berg), New Relic
 - [Cijo Thomas](https://github.com/cijothomas), Microsoft
-- [John Watson](https://github.com/jkwatson), Splunk
 - [Leighton Chen](https://github.com/lzchen), Microsoft
 - [Tyler Yahn](https://github.com/MrAlias), Splunk
 


### PR DESCRIPTION
Follow up https://github.com/open-telemetry/opentelemetry-specification/pull/2594#issuecomment-1152798393.

Thanks @arminru for noticing this!