### PR TITLE
Create the skeleton for the 2022 elections

### DIFF
--- a/elections/2022/governance-committee-candidates.md
+++ b/elections/2022/governance-committee-candidates.md
@@ -1,0 +1,17 @@
+# 2022 OpenTelemetry Governance Committee Candidates
+
+## List of candidates
+
+In alphabetical order:
+
+- [List of candidates](#list-of-candidates)
+
+---
+<!--
+### Candidate 1
+![Candidate Name](static/candidate-picture.png)
+- Company: Company Name
+- GitHub: [username](https://github.com/username)
+Description of candidate
+---
+-->

--- a/elections/2022/governance-committee-election.md
+++ b/elections/2022/governance-committee-election.md
@@ -6,19 +6,12 @@ This document lays out the 2022 election process per the OpenTelemetry governanc
 
 This election should fill four seats.
 
-The schedule is yet to be determined, and the two current alternatives are:
+Election schedule:
 
 * 6 October 2022 - final deadline to submit nominations
 * 8 October 2022 - official nominees list published
 * 18 October 2022 to 20 October 2022 - voting takes place
 * 22 October 2022 - results announced
-
-* 20 October 2022 - final deadline to submit nominations
-* 22 October 2022 - official nominees list published
-* 1 November 2022 to 3 November 2022 - voting takes place
-* 5 November 2022 - results announced
-
-_DRAFT:_ for practical effects, the remaining of this document assumes that the first option is selected.
 
 We highly encourage participation in this election cycle to ensure that the community is well-represented by the Governance Committee.
 
@@ -26,7 +19,7 @@ We highly encourage participation in this election cycle to ensure that the comm
 
 * If you've been nominated or are willing to nominate yourself: check the [charter document](https://github.com/open-telemetry/community/blob/main/governance-charter.md#establishment-of-a-governance-committee) and confirm you are ready for the commitment. Make sure to provide all necessary information before 8 October 2022 00:00 UTC
 * If you are an active community member: confirm that you are on the voters list (see [election announcements issue](https://github.com/open-telemetry/community/issues/1173)) or register yourself before 18 October 2022 00:00 UTC.
-* Vote between 18 October 2022 00:00 UTC and 20 October 2022 00:00 UTC via the voting link (link to follow)
+* Vote between 18 October 2022 00:00 UTC and 20 October 2022 23:59 UTC via the voting link (link to follow)
 * Keep being awesome and contributing to the project!
 
 # Vacancies
@@ -96,7 +89,7 @@ Voting will close on 21 October 2022 at 00:00 UTC. Nominees will be stack ranked
 
 | Date                      | Activity                                                                                                                                    |
 |---------------------------|---------------------------------------------------------------------------------------------------------------------------------------------|
-|  9 September 2022         | This document announced                                                                                                                     |
+| 12 September 2022         | This document announced                                                                                                                     |
 | 12 September 2022         | Election blog post and call for nominations                                                                                                 |
 |  7 October 2022 23:59 UTC | End of call for nominations                                                                                                                 |
 |  8 October 2022           | Preliminary list of nominees announced.                                                                                                     |

--- a/elections/2022/governance-committee-election.md
+++ b/elections/2022/governance-committee-election.md
@@ -53,7 +53,7 @@ Anyone can track the 2022 election process via [this GitHub issue](https://githu
 
 # Nominations
 
-As per [the charter document](https://github.com/open-telemetry/community/blob/main/governance-charter.md#establishment-of-a-governance-committee), anybody is eligible to run for the Governance Committee. During the "call for nomination" period, people can be nominated or nominate themselves by submitting a Pull Request adding said candidate to the [governance-committee-candidates.md](https://github.com/open-telemetry/community/blob/main/elections/2021/governance-committee-candidates.md) file in the OpenTelemetry community repository. The template in that file includes the following columns:
+As per [the charter document](https://github.com/open-telemetry/community/blob/main/governance-charter.md#establishment-of-a-governance-committee), anybody is eligible to run for the Governance Committee. During the "call for nomination" period, people can be nominated or nominate themselves by submitting a Pull Request adding said candidate to the [governance-committee-candidates.md](https://github.com/open-telemetry/community/blob/main/elections/2022/governance-committee-candidates.md) file in the OpenTelemetry community repository. The template in that file includes the following columns:
 
 * Full name
 * GitHub alias

--- a/elections/2022/governance-committee-election.md
+++ b/elections/2022/governance-committee-election.md
@@ -1,0 +1,108 @@
+# OpenTelemetry 2022 Governance Committee election
+
+Please see **[the list of candidates running in the election here](./governance-committee-candidates.md)**.
+
+This document lays out the 2022 election process per the OpenTelemetry governance committee [charter document](https://github.com/open-telemetry/community/blob/main/governance-charter.md#establishment-of-a-governance-committee) requirements.
+
+This election should fill four seats.
+
+The schedule is yet to be determined, and the two current alternatives are:
+
+* 6 October 2022 - final deadline to submit nominations
+* 8 October 2022 - official nominees list published
+* 18 October 2022 to 20 October 2022 - voting takes place
+* 22 October 2022 - results announced
+
+* 20 October 2022 - final deadline to submit nominations
+* 22 October 2022 - official nominees list published
+* 1 November 2022 to 3 November 2022 - voting takes place
+* 5 November 2022 - results announced
+
+_DRAFT:_ for practical effects, the remaining of this document assumes that the first option is selected.
+
+We highly encourage participation in this election cycle to ensure that the community is well-represented by the Governance Committee.
+
+# TL;DR
+
+* If you've been nominated or are willing to nominate yourself: check the [charter document](https://github.com/open-telemetry/community/blob/main/governance-charter.md#establishment-of-a-governance-committee) and confirm you are ready for the commitment. Make sure to provide all necessary information before 8 October 2022 00:00 UTC
+* If you are an active community member: confirm that you are on the voters list (see [election announcements issue](https://github.com/open-telemetry/community/issues/1173)) or register yourself before 18 October 2022 00:00 UTC.
+* Vote between 18 October 2022 00:00 UTC and 20 October 2022 00:00 UTC via the voting link (link to follow)
+* Keep being awesome and contributing to the project!
+
+# Vacancies
+
+Current governance committee members (alphabetical order):
+
+* [Alolita Sharma](https://github.com/alolita), AWS, until October 2022
+* [Ben Sigelman](https://github.com/bhs), Lightstep, until October 2023
+* [Bogdan Drutu](https://github.com/BogdanDrutu), Splunk, until October 2023
+* [Daniel Dyla](https://github.com/dyladan), Dynatrace, until October 2022
+* [Juraci Paixão Kröhling](https://github.com/jpkrohling), Grafana Labs, until October 2023
+* [Liz Fong-Jones](https://github.com/lizthegrey), Honeycomb, until October 2022
+* [Morgan James McLean](https://github.com/mtwo), Splunk, until October 2022
+* [Ted Young](https://github.com/tedsuo), Lightstep, until October 2023
+* [Yuri Shkuro](https://github.com/yurishkuro), Facebook, until October 2023
+
+Four people must be elected in this election, each with two-year terms. Note that four current Governance Committee members end terms as part of this election cycle, though they are welcome to run again for one of the four vacancies.
+
+After this election and until October 2023, the Governance Committee will have nine seats, all of which will be elected positions. Please refer to the [charter document](https://github.com/open-telemetry/community/blob/main/governance-charter.md#establishment-of-a-governance-committee) for more information.
+
+# Voting process
+
+Anyone can track the 2022 election process via [this GitHub issue](https://github.com/open-telemetry/community/issues/1163). This year's election committee consists of governance committee members Bogdan Drutu and Juraci Paixão Kröhling, with assistance from Ben Sigelman, none of whom are up for reelection this year. We strive for transparency in the election process and hold the community's interests as our priority. In particular, we will ensure that all documents and assets related to the 2022 election process are public, and we will attempt to record and distribute notes for any meetings held as part of this process.
+
+# Nominations
+
+As per [the charter document](https://github.com/open-telemetry/community/blob/main/governance-charter.md#establishment-of-a-governance-committee), anybody is eligible to run for the Governance Committee. During the "call for nomination" period, people can be nominated or nominate themselves by submitting a Pull Request adding said candidate to the [governance-committee-candidates.md](https://github.com/open-telemetry/community/blob/main/elections/2021/governance-committee-candidates.md) file in the OpenTelemetry community repository. The template in that file includes the following columns:
+
+* Full name
+* GitHub alias
+* Company affiliation (if applicable)
+* Short bio or reasoning to join the Governance Committee (no more than a short paragraph)
+* _Optional_: photo/picture of a nominee
+
+The election committee will not merge the Pull Request until the candidate has confirmed their desire to be nominated (if not self-nominating) and ratified via PR comments.
+
+Nominees should also send their email address to [cncf-opentelemetry-governance@lists.cncf.io](mailto:cncf-opentelemetry-governance@lists.cncf.io) – it will be kept private and used only for candidate communications as the election process proceeds.
+
+The Governance Committee or appointed people will contact every nominee directly to ensure the commitment and desire to be nominated.
+
+# Voter Eligibility
+
+All [members of standing](https://github.com/open-telemetry/community/blob/main/governance-charter.md#members-of-standing) will automatically be eligible to vote. To confirm your eligibility status, see the [election announcements issue](https://github.com/open-telemetry/community/issues/852). If your code contributions do not meet eligibility requirements but you believe your non-code contributions should make you eligible to vote, you can request an exemption by submitting an exemption request form (link to follow).
+
+One of two options will be available in the form to prove eligibility:
+
+* GitHub handle
+* List either:
+  * Your contributions to OpenTelemetry that make you eligible to vote, or
+  * Your non-code contributions per the [Members of Standing section of the charter](https://github.com/open-telemetry/community/blob/main/governance-charter.md#members-of-standing): particularly, your relationship to a well-known project that's taken a hard dependency on OpenTelemetry, or your involvement with a well-known organization's adoption of OpenTelemetry as an end-user.
+
+All exemption forms are private. Only the current governance and election committee members will have access to this information. The governance committee will discard the lists one month after the election.
+
+# Vote
+
+Everyone with voting rights may log into Helios Voting (link to follow) using their GitHub account. Voting will be approval voting, where each voter may select up to five candidates. The five candidates with the most votes win the election.
+
+The election committee will accept late registrations to vote and requests to re-send the voting link via email to [cncf-opentelemetry-governance@lists.cncf.io](mailto:cncf-opentelemetry-governance@lists.cncf.io). We encourage pre-registration to minimize the effort required to run this election.
+
+Per Helios, voting is entirely private: nobody will know any individual's vote.
+
+# Results
+
+Voting will close on 21 October 2022 at 00:00 UTC. Nominees will be stack ranked. If a nominee becomes ineligible (for instance, if more than three topmost nominees work for the same company), the election committee will skip those nominees and pick the nominee with the next-highest score. The exact scores for each candidate will be public.
+
+# Schedule
+
+| Date                      | Activity                                                                                                                                    |
+|---------------------------|---------------------------------------------------------------------------------------------------------------------------------------------|
+|  9 September 2022         | This document announced                                                                                                                     |
+| 12 September 2022         | Election blog post and call for nominations                                                                                                 |
+|  7 October 2022 23:59 UTC | End of call for nominations                                                                                                                 |
+|  8 October 2022           | Preliminary list of nominees announced.                                                                                                     |
+|  8 October 2022           | Nominees ratified, and Governance Committee ensures nominees' commitment.                                                                    |
+| 11 October 2022           | List of nominees is finalized on [community](https://github.com/open-telemetry/community) GitHub and advertised via mailing list and Gitter |
+| 17 October 2022 23:59 UTC | Last day to apply for a member of standing exemption                                                                                        |
+| 18 October 2022 00:00 UTC | Voting period begins                                                                                                                        |
+| 20 October 2022 00:00 UTC | voting ends                                                                                                                                 |
+| 22 October 2022           | Results are announced                                                                                                                       |


### PR DESCRIPTION
This change creates the skeleton directory for the 2022 elections,
providing the initial draft for the election document.

Fixes #1170

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>