### PR TITLE
Add Jack Berg as log spec approver

### DIFF
--- a/community-members.md
+++ b/community-members.md
@@ -63,6 +63,7 @@ Logs Approvers:
 - [Christian Beedgen](https://github.com/kumoroku), Sumo Logic
 - [Daniel Jaglowski](https://github.com/djaglowski), observIQ
 - [David Poncelow](https://github.com/zenmoto), Splunk
+- [Jack Berg](https://github.com/jack-berg), New Relic
 
 ## Java
 


### PR DESCRIPTION
Jack has been actively driving log spec changes and the Logging SIG for many months now. The TC and current log spec approvers have unanimously agreed that Jack can be a great log spec approver.