### PR TITLE
Remove markdown header formatting and update ToC

### DIFF
--- a/elections/2022/governance-committee-candidates.md
+++ b/elections/2022/governance-committee-candidates.md
@@ -37,7 +37,6 @@ OpenTelemetry Community Day. If elected for a second term, Daniel would focus on
 experience, especially for developers new to OpenTelemetry and Open Source, as well
 as continue to focus on making sure OpenTelemetry continues to be a safe, inclusive,
 and rewarding experience for contributors, maintainers, and users.
-=======
 
 ### Michael Hausenblas
 

--- a/elections/2022/governance-committee-candidates.md
+++ b/elections/2022/governance-committee-candidates.md
@@ -4,9 +4,9 @@
 
 In alphabetical order:
 
+- [Daniel Dyla](#daniel-dyla)
 - [Michael Hausenblas](#michael-hausenblas)
-
----
+- [Sean Marciniak](#sean-marciniak)
 
 <!--
 ### Candidate 1
@@ -37,6 +37,8 @@ OpenTelemetry Community Day. If elected for a second term, Daniel would focus on
 experience, especially for developers new to OpenTelemetry and Open Source, as well
 as continue to focus on making sure OpenTelemetry continues to be a safe, inclusive,
 and rewarding experience for contributors, maintainers, and users.
+
+---
 
 ### Michael Hausenblas
 


### PR DESCRIPTION
Looks like someone else's nomination accidentally added a header formatting to the whole paragraph for my nomination :) This reverts that.

It also updates the table of contents and makes the horizontal rule formatting consistent