### PR TITLE
Update GC after 2022 elections

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -12,4 +12,4 @@
 #  https://help.github.com/en/articles/about-code-owners
 #
 
-*  @bhs @bogdandrutu @yurishkuro @lizthegrey @mtwo @tedsuo @alolita @dyladan @jpkrohling
+*  @alolita @bhs @bogdandrutu @dyladan @jpkrohling @mtwo @tedsuo @trask @yurishkuro

--- a/community-members.md
+++ b/community-members.md
@@ -6,14 +6,14 @@ This is the current Governance Committee, per the [Governance Committee
 Charter](https://github.com/open-telemetry/community/blob/master/governance-charter.md),
 in alphabetical order:
 
-- [Alolita Sharma](https://github.com/alolita), AWS, until October 2022
+- [Alolita Sharma](https://github.com/alolita), AWS, until October 2024
 - [Ben Sigelman](https://github.com/bhs), Lightstep, until October 2023
 - [Bogdan Drutu](https://github.com/BogdanDrutu), Splunk, until October 2023
-- [Daniel Dyla](https://github.com/dyladan), Dynatrace, until October 2022
+- [Daniel Dyla](https://github.com/dyladan), Dynatrace, until October 2024
 - [Juraci Paixão Kröhling](https://github.com/jpkrohling), Grafana Labs, until October 2023
-- [Liz Fong-Jones](https://github.com/lizthegrey), Honeycomb, until October 2022
-- [Morgan McLean](https://github.com/mtwo), Splunk, until October 2022
+- [Morgan McLean](https://github.com/mtwo), Splunk, until October 2024
 - [Ted Young](https://github.com/tedsuo), Lightstep, until October 2023
+- [Trask Stalnaker](https://github.com/trask), Microsoft, until October 2024
 - [Yuri Shkuro](https://github.com/yurishkuro), Meta, until October 2023
 
 ## Technical Committee

--- a/community-members.md
+++ b/community-members.md
@@ -163,5 +163,6 @@ Rust, Swift
 ## Governance Committee Emeritus
 
 - [Constance Caramanolis](https://github.com/ccaraman), Splunk, until October 2021
+- [Liz Fong-Jones](https://github.com/lizthegrey), Honeycomb, until October 2022
 - [Sarah Novotny](https://github.com/SarahNovotny), Microsoft, until October 2021
 - [Sergey Kanzhelev](https://github.com/SergeyKanzhelev), Google, until October 2021


### PR DESCRIPTION
Update the current GC based on the 2022 elections.

Related to: https://github.com/open-telemetry/community/issues/1169

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>
