### PR TITLE
Document repo settings applied to community repo itself

### DIFF
--- a/.github/repository-settings.md
+++ b/.github/repository-settings.md
@@ -1,0 +1,20 @@
+# Repository settings
+
+This document describes any changes that have been made to the
+settings for this repository beyond the [OpenTelemetry default repository
+settings](../docs/how-to-configure-new-repository.md#repository-settings).
+
+## General > Pull Requests
+
+* Allow auto-merge
+
+## Branch protections
+
+### `main`
+
+* Required number of approvals before merging: `2`
+* Require conversation resolution before merging: :heavy_check_mark:
+
+### `**/**`
+
+* Allow deletions: :heavy_check_mark:


### PR DESCRIPTION
Following the new guidance at https://github.com/open-telemetry/community/blob/main/docs/how-to-configure-new-repository.md#collaborators-and-teams:

> If requested, `foo-maintainers` will be granted `Admin` permissions, and in return they must document any changes they make to the repository settings in a file named `.github/repository-settings.md` in their repository (other than temporarily disabling "Do not allow bypassing the above settings", see branch protection rules below).
