### PR TITLE
Add 'needs author feedback' workflow

### DIFF
--- a/.github/workflows/issue-management-feedback-label.yml
+++ b/.github/workflows/issue-management-feedback-label.yml
@@ -1,0 +1,21 @@
+name: Issue management - remove needs feedback label
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  issue_comment:
+    if: >
+      contains(github.event.issue.labels.*.name, 'needs author feedback') &&
+      github.event.comment.user.login == github.event.issue.user.login
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Remove label
+        env:
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh issue edit --remove-label "needs author feedback" $ISSUE_NUMBER

--- a/.github/workflows/issue-management-stale-action.yml
+++ b/.github/workflows/issue-management-stale-action.yml
@@ -1,0 +1,21 @@
+name: Issue management - run stale action
+
+on:
+  schedule:
+    # Hourly at minute 23
+    - cron: "23 * * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v6
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          days-before-stale: 7
+          days-before-close: 7
+          only-labels: "needs author feedback"
+          stale-message: >
+            This has been automatically marked as stale because it has been marked
+            as needing author feedback and has not had any activity for 7 days.
+            It will be closed if no further activity occurs within 7 days of this comment.


### PR DESCRIPTION
I like this stale workflow, which requires maintainers to add a "needs author feedback" label to an issue or PR before the stale bot takes effect, and the "needs author feedback" label is automatically removed on any further comment by the issue or PR author.

These are some example issues where I would like to apply this label: #933, #1137, #690, #681.
