### PR TITLE
Fix stale issue/pr auto-comment

### DIFF
--- a/.github/workflows/issue-management-stale-action.yml
+++ b/.github/workflows/issue-management-stale-action.yml
@@ -15,7 +15,11 @@ jobs:
           days-before-stale: 7
           days-before-close: 7
           only-labels: "needs author feedback"
-          stale-message: >
+          stale-issue-message: >
+            This has been automatically marked as stale because it has been marked
+            as needing author feedback and has not had any activity for 7 days.
+            It will be closed if no further activity occurs within 7 days of this comment.
+          stale-pr-message: >
             This has been automatically marked as stale because it has been marked
             as needing author feedback and has not had any activity for 7 days.
             It will be closed if no further activity occurs within 7 days of this comment.


### PR DESCRIPTION
I noticed the new stale action didn't add comment to issue b/c I used the wrong [option](https://github.com/actions/stale#list-of-input-options).