### PR TITLE
Add dependabot to keep github action(s) up-to-date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Currently there's only one github action in this repo (but it's outdated):

https://github.com/open-telemetry/community/blob/95351dce4361381d57b640102972d71026680f6b/.github/workflows/issue-management-stale-action.yml#L12
