### PR TITLE
Update opentelemetrybot details

### DIFF
--- a/assets.md
+++ b/assets.md
@@ -130,6 +130,8 @@ Link: [@opentelemetrybot](https://github.com/opentelemetrybot)
 
 - Admins: [@trask](https://github.com/trask) and
   [@open-telemetry/governance-committee](https://github.com/orgs/open-telemetry/teams/governance-committee)
+  (GitHub password and associated 2FA for the `@opentelemetrybot` account are available in the OpenTelemetry Governance
+  1Password)
 - Admins for the associated GitHub organization secret:
   [@open-telemetry/technical-committee](https://github.com/orgs/open-telemetry/teams/technical-committee)
 
@@ -159,7 +161,8 @@ The OpenTelemetry Bot addresses two common issues:
    [Personal Access Token][] for [@opentelemetrybot](https://github.com/opentelemetrybot) with `public_repo`
    scope for the OpenTelemetry Bot that you can use to bypass this limitation.
 
-   Maintainers can open an issue in the community repository to have their repository granted access to this
-   organization secret.
+   The personal access token also has `workflow` scope which is needed when merging upstream changes of
+   `.github/workflow` files into opentelemetrybot's forks (these forks are used for automatically opening PRs against
+   external repos).
 
    [Personal Access Token]: https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token

--- a/assets.md
+++ b/assets.md
@@ -165,4 +165,7 @@ The OpenTelemetry Bot addresses two common issues:
    `.github/workflow` files into opentelemetrybot's forks (these forks are used for automatically opening PRs against
    external repos).
 
+   Maintainers can open an issue in the community repository to have their repository granted access to this
+   organization secret.
+
    [Personal Access Token]: https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token


### PR DESCRIPTION
Adds note about 2FA being available now in 1Password.

Removes note about maintainers needing to request access to org secret, because I believe the secret has been made available to all repos (need someone from @open-telemetry/technical-committee to confirm).

Adds note about additional scope that has been granted to the personal access token.