### PR TITLE
Add StackOverflow -> Slack Channeler

### DIFF
--- a/tools/so-channeler/README.md
+++ b/tools/so-channeler/README.md
@@ -1,0 +1,58 @@
+# StackOverflow -> Slack Question Channeler
+
+This is a Lambda function designed to channel questions from StackOverflow
+tagged with `#open-telemetry` into a designated Slack channel.
+
+## Packaging and Deployment
+
+1. Run `pip3 install requests -t ./package` to install the `requests` library
+   into the `package` directory.
+2. Copy `lambda_function.py` into the `package` directory.
+3. Zip the contents of the `package` directory into a zip file named
+   `lambda_function.zip`. **Do not zip the `package` directory itself, zip its
+   contents**.
+4. Upload the zip file to AWS Lambda. Deploy the function.
+5. Adjust the timeout to ~1 minute (adjust as needed) and set environment
+   variables.
+6. Create an EventBridge trigger with the desired schedule (hourly would be
+   `cron(0 * * * ? *)`) and set the target to the Lambda function.
+
+## Requirements
+
+The Lambda function requires the following environment variables to be set:
+
+- `SLACK_WEBHOOK_URL`: The URL of the Slack webhook to post to.
+- `S3_BUCKET_NAME`: The name of the S3 bucket to store the last timestamp in.
+
+It also requires an IAM Policy and Role. The policy is below (replace
+`your-bucket-name` with the name of the bucket created):
+
+``` json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "s3:GetObject",
+                "s3:PutObject"
+            ],
+            "Resource": "arn:aws:s3:::your-bucket-name/*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "logs:CreateLogGroup",
+                "logs:CreateLogStream",
+                "logs:PutLogEvents"
+            ],
+            "Resource": "arn:aws:logs:*:*:*"
+        }
+    ]
+}
+```
+
+Attach this policy to a role and attach the role to the Lambda function.
+
+You will also need a Slack App with Incoming Webhooks enabled. Set the webook
+environment variable to the URL given to you by this app.

--- a/tools/so-channeler/lambda_function.py
+++ b/tools/so-channeler/lambda_function.py
@@ -1,0 +1,54 @@
+import os
+import json
+import requests
+from datetime import datetime
+from boto3 import client
+
+STACK_OVERFLOW_API = "https://api.stackexchange.com/2.3/search"
+SLACK_WEBHOOK_URL = os.environ['SLACK_WEBHOOK_URL']
+S3_BUCKET_NAME = os.environ['S3_BUCKET_NAME']
+S3_OBJECT_KEY = "latest_question_timestamp.txt"
+
+def get_latest_question_timestamp(s3_client):
+    try:
+        response = s3_client.get_object(Bucket=S3_BUCKET_NAME, Key=S3_OBJECT_KEY)
+        return int(response['Body'].read().decode('utf-8'))
+    except Exception as e:
+        return 0
+
+def update_latest_question_timestamp(s3_client, latest_timestamp):
+    s3_client.put_object(Bucket=S3_BUCKET_NAME, Key=S3_OBJECT_KEY, Body=str(latest_timestamp))
+
+def fetch_questions(latest_timestamp):
+    params = {
+        "tagged": "open-telemetry",
+        "sort": "creation",
+        "site": "stackoverflow",
+        "fromdate": latest_timestamp
+    }
+    response = requests.get(STACK_OVERFLOW_API, params=params)
+    response.raise_for_status()
+    return response.json().get('items', [])
+
+def format_question(question):
+    title = question['title']
+    link = question['link']
+    return f"New question: <{link}|{title}>"
+
+def post_to_slack(message):
+    headers = {"Content-Type": "application/json"}
+    data = {"text": message}
+    response = requests.post(SLACK_WEBHOOK_URL, headers=headers, data=json.dumps(data))
+    response.raise_for_status()
+
+def lambda_handler(event, context):
+    s3_client = client('s3')
+    latest_timestamp = get_latest_question_timestamp(s3_client)
+    questions = fetch_questions(latest_timestamp)
+
+    for question in questions:
+        message = format_question(question)
+        post_to_slack(message)
+        latest_timestamp = max(latest_timestamp, question['creation_date'])
+
+    update_latest_question_timestamp(s3_client, latest_timestamp)


### PR DESCRIPTION
To support community efforts at answering questions on StackOverflow, this Lambda function will query the SO API and post new results in a specified channel via Slack webhook.

We'll need to figure out what AWS account to run this on -- I can probably start it on my team account, but we'll need a Slack app connected to the CNCF Slack instance which I can request. Mostly just wanted to make sure the code was archived in this repo.