### PR TITLE
Merge Logs SIG meeting into general Specification meeting

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ SIG-specific GitHub discussions.
 Name|Meeting Time|Meeting Notes|Discussions|[Technical Committee](./community-members.md#technical-committee) Sponsors|
 ----|------------|-------------|-----------|-----------|
 Specification: General|Every Tuesday at 08:00 PT|[Google Doc](https://docs.google.com/document/d/1pdvPeKjA8v8w_fGKAN68JjWBmVJtPCpqdi9IZrd6eEo/edit)|[Slack](https://cloud-native.slack.com/archives/C01N7PP1THC)
-Specification: Logs|Every Wednesday at 10:00 PT|[Google Doc](https://docs.google.com/document/d/1P_wkLEomswd0M0eNNnxSOe6U-EOpCZaMIIxKuM4frw8)|[Slack](https://cloud-native.slack.com/archives/C01N5UCHTEH)|[Tigran Najaryan](https://github.com/tigrannajaryan)
+Specification: Logs|Merged into "Specification: General"|See above|[Slack](https://cloud-native.slack.com/archives/C01N5UCHTEH)|[Tigran Najaryan](https://github.com/tigrannajaryan)
 Specification: Sampling|Every Thursday at 08:00 PT|[Google Doc](https://docs.google.com/document/d/1gASMhmxNt9qCa8czEMheGlUW2xpORiYoD7dBD7aNtbQ/)|[Slack](https://cloud-native.slack.com/archives/C027DS6GZD3)|[Josh MacDonald](https://github.com/jmacd)
 Specification: Configuration|Every other Monday at 8:00 PT|[Google Doc](https://docs.google.com/document/d/1uNgWQLQZcSVfBLRXfW9XCVJmKa5NH9R15fSOXhmpGWw/edit)|[Slack](https://cloud-native.slack.com/archives/C0476L7UJT1)|[Carlos Alberto](https://github.com/carlosalberto)
 Instrumentation: General|Every Tuesday at 16:00 PT|[Google Doc](https://docs.google.com/document/d/1dWHhyXnfVife-cQ2DW5-d5Ldp1Lq8Rre2UsHpyo8cEE/)|[Slack](https://cloud-native.slack.com/archives/C01QZFGMLQ7)


### PR DESCRIPTION
Now that Logs Bridge API/SDK spec is stable we are merging the Log SIG meeting into general spec meeting. This was discussed in Logs SIG last time.

If in the future active work on Logs spec resumes we will restore the separate meeting.