### PR TITLE
Update "Using Github Apps, etc" page

### DIFF
--- a/docs/using-github-extensions.md
+++ b/docs/using-github-extensions.md
@@ -15,15 +15,12 @@ Extensions, apps, or bots that can **arbitrarily modify code are NOT allowed**. 
 - GC member needs to approve with no other GC members raising concerns. It is recommended to discuss each extension, app, or bot that is about to be installed at GC meeting for awareness.
 - Once GC approval received, TC member will install the extension.
 
-## Writing your GitHub Actions pipelines
+## Writing your GitHub Action workflows
 
 Many GitHub Action workflows do not require a dedicated GitHub account. Good examples are auto-assign workflows for issues and PRs such as [the one used in specifications repo](https://github.com/open-telemetry/opentelemetry-specification/blob/main/.github/workflows/auto-assign-issue.yml).
 
-There are cases when a dedicated account is needed to perform some higher privilege operations. In this cases the recommendation for maintainers is to use their accounts. See [example](https://github.com/open-telemetry/opentelemetry-specification/blob/main/.github/workflows/publish-schemas.yml).
-
-Bot accounts are not recommended, as they require special work to pass CLA checks. If pushing automatically-generated, non-copyrightable code using a bot account is required, an explanation should be sent to the Governance Committee for review and forwarding to the EasyCLA team to exempt the bot's commits from the CLA requirement.
-
-OpenTelemetry does not provide org-level access bot accounts. See discussion here: [open-telemetry/community#551](https://github.com/open-telemetry/community/issues/551).
+If your workflow does require a dedicated GitHub account, you should use [@opentelemetrybot](https://github.com/opentelemetrybot).
+See [OpenTelemetry Bot documentation](../assets.md#opentelemetry-bot) for more details.
 
 ## Creating your own GitHub extensions for OpenTelemetry
 


### PR DESCRIPTION
Two things:
* Fixes broken link, there's no "new link" yet, see https://github.com/open-telemetry/semantic-conventions/issues/11, but it was in outdated doc anyways, so ...
* Updates page to reflect current practices around @opentelemetrybot usage