### PR TITLE
ADOPTERS: direct readers to the website page

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -1,32 +1,5 @@
 # OpenTelemetry Adopters
 
-A non-exhaustive, alphabetized list of organizations that have adopted OpenTelemetry.
+This page has moved, see [Adopters].
 
-| Company                                           | Components                      |  Notes                                                                                                               |
-| ------------------------------------------------  | ------------------------------- |  :-----------------------------------------------------------------------------------------------------------------: |
-| [Amazon Web Services](https://aws.amazon.com/)    | Collector, Java, JS, Python     |  [website](https://aws.amazon.com/otel/)                                                                             |
-| [AppDirect](https://www.appdirect.com/)           | Collector                       |                                                                                                                      |
-| [Care.com](https://www.care.com)                  | Collector, Go, Java, JS, .NET   |                                                                                                                      |
-| [Cloud Scale](https://www.cloudscaleinc.com)      | Collector, Python    |                                                                                                                                  |
-| [Dynatrace](https://www.dynatrace.com/)           | Collector, Java, JS, Python, Go, .NET |                                                                                                                |
-| [EcoBee](https://www.ecobee.com/)                 | Collector, Java                 |  [blog post](https://www.honeycomb.io/blog/bees-working-together-how-ecobees-engineers-adopted-honeycomb-for-visibility-into-system-optimization-and-customer-experience)           |
-| [F5](https://www.f5.com/)                         | Collector.                      |                                                                                                                      |
-| [Google Cloud Platform](https://cloud.google.com) | Collector, Go, Java, JS, Python |                                                                                                                      |
-| [Grafana Labs](https://grafana.com/)              | Collector                       |                                                                                                                      |
-| [Honeycomb](https://honeycomb.io)                 | Go                              |  [blog post](https://www.honeycomb.io/blog/interview-with-honeycomb-engineer-chris-toshok-dogfooding-opentelemetry/) |
-| [Instana](https://www.instana.com)                | Collector, JS                                       |  [docs](https://www.ibm.com/docs/en/obi/current?topic=apis-opentelemetry)                   |
-| [Jaeger](https://jaegertracing.io)                | Jaeger                          |  [blog post](https://medium.com/jaegertracing/jaeger-embraces-opentelemetry-collector-90a545cbc24)                   |
-| [Lightstep](https://lightstep.com)                | Go, JS                          |                                                                                                                      |
-| [Logicmonitor](https://www.logicmonitor.com/)     | Collector, Java, Go, JS, Python, .Net |                                                                                                                |
-| [Logz.io](https://logz.io)                        | Collector, Java, C++, Go, JS, K8s         |  [blog](https://logz.io/learn/opentelemetry-guide/)                                                                                                                    |
-| [Microsoft](https://www.microsoft.com/)           | Collector, C++, Go, Java, JS, Python, Ruby, .NET    | [Azure blog](https://techcommunity.microsoft.com/t5/azure-monitor/opentelemetry-azure-monitor/ba-p/2737823), [Dapr docs](https://docs.dapr.io/operations/monitoring/tracing/otel-collector/), [GitHub blog](https://github.blog/2021-05-26-why-and-how-github-is-adopting-opentelemetry/)  |
-| [OpenTelemetry](https://opentelemetry.io)         | Collector, JS                   |                                                                                                                      |
-| [OrderMyGear](https://www.ordermygear.com/)       |                                 |                                                                                                                      |
-| [PITS Globale Datenrettungsdienste](https://www.pitsdatenrettung.de/) | Python | |
-| [Red Hat](https://redhat.com/)                    | Collector, Operator             |  [website](https://docs.openshift.com/container-platform/4.12/distr_tracing/distr_tracing_arch/distr-tracing-architecture.html)                                                                             |
-| [Sentry Software](https://sentrysoftware.com) | Collector, Java, Semantic Conventions | [blog post](https://www.sentrysoftware.com/blog/2022-07-19/why-sentry-software-chose-opentelemetry-for-hardware-sentry.html) |
-| [Shopify](https://www.shopify.com/)               | Collector, Go, Ruby             |                                                                                                                      |
-| [Splunk](https://www.splunk.com/)                 | Collector, Java, JS             |                                                                                                                      |
-| [Transit](https://transitapp.com/)                |                                 |                                                                                                                      |
-| [Wandera](https://www.wandera.com/)               | Collector                       |                                                                                                                      |
-| [Zocdoc](https://www.zocdoc.com/)                 |                                 |                                                                                                                      |
+[adopters]: https://opentelemetry.io/ecosystem/adopters/

--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -4,5 +4,3 @@ This page has moved to [opentelemetry.io], see [Adopters].
 
 [adopters]: https://opentelemetry.io/ecosystem/adopters/
 [opentelemetry.io]: https://opentelemetry.io
-
-[adopters]: https://opentelemetry.io/ecosystem/adopters/

--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -1,5 +1,8 @@
 # OpenTelemetry Adopters
 
-This page has moved, see [Adopters].
+This page has moved to [opentelemetry.io], see [Adopters].
+
+[adopters]: https://opentelemetry.io/ecosystem/adopters/
+[opentelemetry.io]: https://opentelemetry.io
 
 [adopters]: https://opentelemetry.io/ecosystem/adopters/


### PR DESCRIPTION
- Contributes to https://github.com/open-telemetry/opentelemetry.io/issues/2947
- Replaces page content with a note that the page has moved, and a link to its new home.
- Depends on https://github.com/open-telemetry/opentelemetry.io/pull/2961