### PR TITLE
add system conventions stability working group

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Specification: Configuration|Every other Monday at 8:00 PT|[Google Doc](https://
 Instrumentation: General|Every Tuesday at 16:00 PT|[Google Doc](https://docs.google.com/document/d/1dWHhyXnfVife-cQ2DW5-d5Ldp1Lq8Rre2UsHpyo8cEE/)|[Slack](https://cloud-native.slack.com/archives/C01QZFGMLQ7)
 Instrumentation: Messaging|Every Thursday at 8:00 PT|[Google Doc](https://docs.google.com/document/d/1dWHhyXnfVife-cQ2DW5-d5Ldp1Lq8Rre2UsHpyo8cEE/)|[Slack](https://cloud-native.slack.com/archives/C01QZFGMLQ7)
 Semantic Conventions Working Group|Every Monday at 08:00 PT|[Google Doc](https://docs.google.com/document/d/10xG7DNKWRhxNmFGt3yYd3980a9uwS8lMl2LvQL3VNK8)|[Slack](https://cloud-native.slack.com/archives/C041APFBYQP)|[Armin Ruech](https://github.com/arminru)<br/>[Josh Suereth](https://github.com/jsuereth)<br/>[Reiley Yang](https://github.com/reyang)|
-System Semantic Conventions stability WG|Every Wednesday at 08:30 PT<br/>Between 20.07.2023 - 30.08.2023|[Google Doc](https://docs.google.com/document/d/1p5TH57t43XpxA48onLzX4PIr3g6ydYKCtR_AUlsCnQk)|[Slack](https://cloud-native.slack.com/archives/C05CTFE9U4A)|[Josh Suereth](https://github.com/jsuereth)|
+System Semantic Conventions stability WG|Every Wednesday at 08:30 PT<br/>Between 19.07.2023 - 30.08.2023|[Google Doc](https://docs.google.com/document/d/1p5TH57t43XpxA48onLzX4PIr3g6ydYKCtR_AUlsCnQk)|[Slack](https://cloud-native.slack.com/archives/C05CTFE9U4A)|[Josh Suereth](https://github.com/jsuereth)|
 
 ### Implementation SIGs
 

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Specification: Configuration|Every other Monday at 8:00 PT|[Google Doc](https://
 Instrumentation: General|Every Tuesday at 16:00 PT|[Google Doc](https://docs.google.com/document/d/1dWHhyXnfVife-cQ2DW5-d5Ldp1Lq8Rre2UsHpyo8cEE/)|[Slack](https://cloud-native.slack.com/archives/C01QZFGMLQ7)
 Instrumentation: Messaging|Every Thursday at 8:00 PT|[Google Doc](https://docs.google.com/document/d/1dWHhyXnfVife-cQ2DW5-d5Ldp1Lq8Rre2UsHpyo8cEE/)|[Slack](https://cloud-native.slack.com/archives/C01QZFGMLQ7)
 Semantic Conventions Working Group|Every Monday at 08:00 PT|[Google Doc](https://docs.google.com/document/d/10xG7DNKWRhxNmFGt3yYd3980a9uwS8lMl2LvQL3VNK8)|[Slack](https://cloud-native.slack.com/archives/C041APFBYQP)|[Armin Ruech](https://github.com/arminru)<br/>[Josh Suereth](https://github.com/jsuereth)<br/>[Reiley Yang](https://github.com/reyang)|
+System Semantic Conventions stability WG|Every Wednesday at 08:30 PT<br/>Between 20.07.2023 - 30.08.2023|[Google Doc](https://docs.google.com/document/d/1p5TH57t43XpxA48onLzX4PIr3g6ydYKCtR_AUlsCnQk)|[Slack](https://cloud-native.slack.com/archives/C05CTFE9U4A)|[Josh Suereth](https://github.com/jsuereth)|
 
 ### Implementation SIGs
 


### PR DESCRIPTION
There is no calender invite yet. I [requested access](https://github.com/open-telemetry/community/blob/main/docs/how-to-handle-public-calendar.md#gaining-calendar-permissions) to create one.

Ref https://github.com/open-telemetry/opentelemetry-specification/issues/3556

cc @mx-psi @jsuereth 