### PR TITLE
Add community values, improve code of conduct

### DIFF
--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -32,6 +32,6 @@ believe that the board will not conduct a fair investigation.
 
 When the GC determines that a code of conduct violation happened, it will take
 the actions deemed necessary and appropriate for the event. In more serious
-cases, the community member might be invited to depart from our communities,
+cases, the community member might be requested to depart from our communities,
 giving up any roles they may possess, such as the maintainership of a SIG. In
 extreme cases, the GC can force the departure of the member.

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -1,3 +1,37 @@
 # OpenTelemetry Community Code of Conduct
 
-OpenTelemetry follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).
+The OpenTelemetry project aims to be a welcoming place where new and existing
+members feel safe to respectfully share their opinions and disagreements. We
+want to attract a diverse group of people to collaborate with us, which means
+acknowledging that people come from different backgrounds and cultures. 
+
+We are bound by the [CNCF Code of
+Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md) and
+covered by that in more serious violations and prefer the reporting of
+violations to be made to us as outlined below.
+
+## Reporting violations
+
+If you have seen or experienced unacceptable behavior or anything that would
+make our community less welcoming, please speak up! 
+
+The Governance Committee is the right place to bring your concerns and can be
+reached via cncf-opentelemetry-governance@lists.cncf.io. You can also get in
+touch with any committee member if you feel safer this way: any one of us can
+receive your report and will bring it to the entire group for investigation,
+anonymously if you prefer. The [current list of
+members](https://github.com/open-telemetry/community/blob/main/community-members.md#governance-committee)
+can be found on our community repository, and you can ping any of them directly
+on [CNCF’s Slack](https://slack.cncf.io). The Governance Committee should be
+diverse enough to conduct a neutral investigation having the best interests of
+the project in mind at all times, and the results of the investigation will be
+given back to the reporter in a timely fashion as an official position of the
+GC. If you are unhappy with the outcome, you can escalate that to the CNCF via
+conduct@cncf.io. Feel free to contact the CNCF directly if you have reasons to
+believe that the board will not conduct a fair investigation.
+
+When the GC determines that a code of conduct violation happened, it will take
+the actions deemed necessary and appropriate for the event. In more serious
+cases, the community member might be invited to depart from our communities,
+giving up any roles they may possess, such as the maintainership of a SIG. In
+extreme cases, the GC can force the departure of the member.

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -6,12 +6,12 @@ want to attract a diverse group of people to collaborate with us, which means
 acknowledging that people come from different backgrounds and cultures. 
 
 This project is bound by and abides by the [CNCF Code of
-Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).
+Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md).
 Conflicts should be resolved respectfully between the involved parties, however
 we understand that it may not always be possible without outside help or
 mediation. When needed, any community member can ask for help or report a Code
 of Conduct violation to the Governance Committee as outlined below. The project
-prefers that violations to be reported first to the Governance Committee so that
+prefers for violations to be reported first to the Governance Committee so that
 they may be resolved internally, however, in extreme cases code of conduct
 violations should be reported to the CNCF as outlined in the [CNCF Incident
 Resolution
@@ -25,7 +25,7 @@ Policy](https://github.com/cncf/foundation/blob/main/code-of-conduct/coc-committ
 If you have seen or experienced unacceptable behavior or anything that would
 make our community less welcoming, please speak up!
 
-When the Governing Committee (GC) determines that a code of conduct violation
+When the Governance Committee (GC) determines that a code of conduct violation
 happened, it will take the actions deemed necessary and appropriate for the
 event. In more serious cases, the community member might be requested to depart
 from our communities, giving up any roles they may possess, such as the

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -5,33 +5,57 @@ members feel safe to respectfully share their opinions and disagreements. We
 want to attract a diverse group of people to collaborate with us, which means
 acknowledging that people come from different backgrounds and cultures. 
 
-We are bound by the [CNCF Code of
-Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md) and
-covered by that in more serious violations and prefer the reporting of
-violations to be made to us as outlined below.
+This project is bound by and abides by the [CNCF Code of
+Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).
+Conflicts should be resolved respectfully between the involved parties, however
+we understand that it may not always be possible without outside help or
+mediation. When needed, any community member can ask for help or report a Code
+of Conduct violation to the Governance Committee as outlined below. The project
+prefers that violations to be reported first to the Governance Committee so that
+they may be resolved internally, however, in extreme cases code of conduct
+violations should be reported to the CNCF as outlined in the [CNCF Incident
+Resolution
+Procedures](https://github.com/cncf/foundation/blob/main/code-of-conduct/coc-incident-resolution-procedures.md).
+Anyone who is unsure if a violation should be reported to the project or the
+CNCF should refer to the [CNCF CoC Jurisdiction
+Policy](https://github.com/cncf/foundation/blob/main/code-of-conduct/coc-committee-jurisdiction-policy.md).
 
 ## Reporting violations
 
 If you have seen or experienced unacceptable behavior or anything that would
-make our community less welcoming, please speak up! 
+make our community less welcoming, please speak up!
 
-The Governance Committee is the right place to bring your concerns and can be
-reached via cncf-opentelemetry-governance@lists.cncf.io. You can also get in
-touch with any committee member if you feel safer this way: any one of us can
-receive your report and will bring it to the entire group for investigation,
-anonymously if you prefer. The [current list of
+When the Governing Committee (GC) determines that a code of conduct violation
+happened, it will take the actions deemed necessary and appropriate for the
+event. In more serious cases, the community member might be requested to depart
+from our communities, giving up any roles they may possess, such as the
+maintainership of a SIG. In extreme cases, the GC can force the departure of the
+member.
+
+## Submit in writing
+
+To report a violation in writing, please email
+cncf-opentelemetry-governance@lists.cncf.io, which goes to all GC members. If
+you do not want your report to be received by all GC members, either because you
+want to submit a report anonymously or because one of the GC members has a
+conflict of interest, you may send your report directly to any individual GC
+member. The [current list of
 members](https://github.com/open-telemetry/community/blob/main/community-members.md#governance-committee)
 can be found on our community repository, and you can ping any of them directly
-on [CNCF’s Slack](https://slack.cncf.io). The Governance Committee should be
-diverse enough to conduct a neutral investigation having the best interests of
-the project in mind at all times, and the results of the investigation will be
-given back to the reporter in a timely fashion as an official position of the
-GC. If you are unhappy with the outcome, you can escalate that to the CNCF via
-conduct@cncf.io. Feel free to contact the CNCF directly if you have reasons to
-believe that the board will not conduct a fair investigation.
+on [CNCF’s Slack](https://slack.cncf.io)
 
-When the GC determines that a code of conduct violation happened, it will take
-the actions deemed necessary and appropriate for the event. In more serious
-cases, the community member might be requested to depart from our communities,
-giving up any roles they may possess, such as the maintainership of a SIG. In
-extreme cases, the GC can force the departure of the member.
+## Submit in spoken conversation
+
+If you prefer to report the violation in a spoken conversation, you may request
+a telephone conversation or virtual meeting with a GC member.
+
+# How to report anonymously
+
+If you desire to submit a report anonymously, please send a message directly to
+any individual member of our GC through the CNCF Slack and let them know you
+would like to submit a Code of Conduct report anonymously. If you submit your
+report anonymously, that member of the GC will share the contents of your report
+with the rest of the GC, but they will not disclose your identity as the
+reporter to the other members of the GC (unless such disclosure is necessary to
+comply with applicable laws or a court order, or to protect you or someone else
+from imminent danger).

--- a/mission-vision-values.md
+++ b/mission-vision-values.md
@@ -133,7 +133,7 @@ While we want to encourage everyone to express themselves in their own way,
 there are some behaviors that we encourage you to adopt while interacting with
 other community members.
 
-#### Act on behalf of the project
+### Act on behalf of the project
 
 It’s no secret that a good number of maintainers of the project are employed by
 companies with commercial interests in OpenTelemetry, especially vendors in the
@@ -143,7 +143,7 @@ those of their employers so that the relationship is beneficial to all parties,
 but when acting as a maintainer or contributor to the project, community members
 are expected to wear the project’s hat. 
 
-##### Disclose potential conflicts of interest
+### Disclose potential conflicts of interest
 
 Even within the project, people might have different hats: a Collector
 maintainer might be part of the Governance Committee, a JavaScript maintainer
@@ -152,7 +152,7 @@ message can be ambiguous, make it clear which hat you are using. For instance,
 during a GC call, a person who is also a maintainer of the Collector might say:
 “as a Collector maintainer, I believe that…, while as a GC member, I believe …”
 
-#### Assume positive intent
+### Assume positive intent
 
 We all have different priorities in our daily jobs, and while some of us are
 employed to work full time on OpenTelemetry, some of us are paid to improve
@@ -163,7 +163,7 @@ while the proposal might seem skewed towards a specific perspective at first,
 it’s very likely that the author is open to improving it if different
 perspectives are provided.
 
-#### Respectfully disagree
+### Respectfully disagree
 
 Many decisions are made every day as part of our project. Despite giving our
 best, not all decisions are the right ones. We encourage ideas and solutions to
@@ -177,7 +177,7 @@ of the matter should be resolved within the SIG by the maintainers or, in
 ultimate cases, by the Technical Committee (TC), non-technical matters should be
 brought up to the Governance Committee.
 
-#### Be nice
+### Be nice
 
 As evidenced by Erin Meyer’s [“The Cultural Map”
 book](https://erinmeyer.com/books/the-culture-map/), people from different

--- a/mission-vision-values.md
+++ b/mission-vision-values.md
@@ -116,3 +116,75 @@ to degrade gracefully as needed.
 OpenTelemetry users should not have to choose between high-quality telemetry and
 a performant application. High performance is a requirement for OpenTelemetry,
 and unexpected interference effects in the host application are unacceptable.
+
+## Community values &mdash; the principles that guide our interactions
+
+The OpenTelemetry project aims to be a welcoming place where new and existing
+members feel safe to respectfully share their opinions and disagreements. We
+want to attract a diverse group of people to collaborate with us, which means
+acknowledging that people come from different backgrounds and cultures. 
+
+There might be situations where community members act in a dubious manner. If
+you have seen or experienced unacceptable behavior or anything that would make
+our community less welcoming, please speak up! See [our code of
+conduct](./code-of-conduct) for more information on how to report bad behavior.
+
+While we want to encourage everyone to express themselves in their own way,
+there are some behaviors that we encourage you to adopt while interacting with
+other community members.
+
+#### Act on behalf of the project
+
+It’s no secret that a good number of maintainers of the project are employed by
+companies with commercial interests in OpenTelemetry, especially vendors in the
+observability space. That said, we expect community members to act in the best
+interests of the project. Each member’s priorities can (and should!) align with
+those of their employers so that the relationship is beneficial to all parties,
+but when acting as a maintainer or contributor to the project, community members
+are expected to wear the project’s hat. 
+
+##### Disclose potential conflicts of interest
+
+Even within the project, people might have different hats: a Collector
+maintainer might be part of the Governance Committee, a JavaScript maintainer
+might be part of the Technical Committee, and so on. When the context of your
+message can be ambiguous, make it clear which hat you are using. For instance,
+during a GC call, a person who is also a maintainer of the Collector might say:
+“as a Collector maintainer, I believe that…, while as a GC member, I believe …”
+
+#### Assume positive intent
+
+We all have different priorities in our daily jobs, and while some of us are
+employed to work full time on OpenTelemetry, some of us are paid to improve
+specific parts of the project according to the commercial interests of our
+employers. When reviewing proposals, documents, or code, take the different
+perspectives into consideration, but more importantly, assume positive intent:
+while the proposal might seem skewed towards a specific perspective at first,
+it’s very likely that the author is open to improving it if different
+perspectives are provided.
+
+#### Respectfully disagree
+
+Many decisions are made every day as part of our project. Despite giving our
+best, not all decisions are the right ones. We encourage ideas and solutions to
+be proposed and debated until an agreement is reached or until the “disagree and
+commit” stage is reached. What we cannot tolerate is turning attacks against
+ideas into attacks against people: in the heat of the moment, it might be
+tempting to do an ad hominem attack but it’s always wrong. If you have reasons
+to believe the person you are debating with is not acting on behalf of the
+project, seek mediation instead of engaging further. While the technical merits
+of the matter should be resolved within the SIG by the maintainers or, in
+ultimate cases, by the Technical Committee (TC), non-technical matters should be
+brought up to the Governance Committee.
+
+#### Be nice
+
+As evidenced by Erin Meyer’s [“The Cultural Map”
+book](https://erinmeyer.com/books/the-culture-map/), people from different
+cultural backgrounds have different ways of communicating. While we don’t expect
+you to be an expert in [“reading the
+air”](https://www.bbc.com/worklife/article/20200129-what-is-reading-the-air-in-japan),
+we expect that you be nice to other folks and that your communication is clear
+without requiring the other parties to infer what’s not explicitly written
+there. This includes being minimally polite while transmitting your thoughts and
+keeping snarky or inappropriate comments to yourself.

--- a/mission-vision-values.md
+++ b/mission-vision-values.md
@@ -127,7 +127,7 @@ acknowledging that people come from different backgrounds and cultures.
 There might be situations where community members act in a dubious manner. If
 you have seen or experienced unacceptable behavior or anything that would make
 our community less welcoming, please speak up! See [our code of
-conduct](./code-of-conduct) for more information on how to report bad behavior.
+conduct](./code-of-conduct.md) for more information on how to report bad behavior.
 
 While we want to encourage everyone to express themselves in their own way,
 there are some behaviors that we encourage you to adopt while interacting with

--- a/mission-vision-values.md
+++ b/mission-vision-values.md
@@ -171,8 +171,8 @@ best, not all decisions are the right ones. We encourage ideas and solutions to
 be proposed and debated until an agreement is reached or until the “disagree and
 commit” stage is reached. What we cannot tolerate is turning attacks against
 ideas into attacks against people: in the heat of the moment, it might be
-tempting to do an ad hominem attack but it’s always wrong. If you have reasons
-to believe the person you are debating with is not acting on behalf of the
+tempting to make an ad hominem attack but it’s always wrong. If you have reasons
+to believe the person you are debating with is not acting in the interest of the
 project, seek mediation instead of engaging further. While the technical merits
 of the matter should be resolved within the SIG by the maintainers or, in
 ultimate cases, by the Technical Committee (TC), non-technical matters should be
@@ -182,9 +182,8 @@ brought up to the Governance Committee.
 
 As evidenced in [The Cultural Map](https://erinmeyer.com/books/the-culture-map/)
 by Erin Meyer, people from different cultural backgrounds have different ways of
-communicating. While we don’t expect you to be an expert in [“reading the
-air”](https://www.bbc.com/worklife/article/20200129-what-is-reading-the-air-in-japan),
-we expect that you be nice to other folks and that your communication is clear
-without requiring the other parties to infer what’s not explicitly written
-there. This includes being minimally polite while transmitting your thoughts and
-keeping snarky or inappropriate comments to yourself.
+communicating. While we don’t expect you to be an expert in capturing unspoken
+nuances, we expect that you be nice to other folks and that your communication
+is clear without requiring the other parties to infer what’s not explicitly
+written there. This includes being minimally polite while transmitting your
+thoughts and keeping snarky or inappropriate comments to yourself.

--- a/mission-vision-values.md
+++ b/mission-vision-values.md
@@ -127,7 +127,8 @@ acknowledging that people come from different backgrounds and cultures.
 There might be situations where community members act in a dubious manner. If
 you have seen or experienced unacceptable behavior or anything that would make
 our community less welcoming, please speak up! See [our code of
-conduct](./code-of-conduct.md) for more information on how to report bad behavior.
+conduct](https://github.com/open-telemetry/community/blob/main/code-of-conduct.md)
+for more information on how to report unacceptable behavior.
 
 While we want to encourage everyone to express themselves in their own way,
 there are some behaviors that we encourage you to adopt while interacting with
@@ -179,10 +180,9 @@ brought up to the Governance Committee.
 
 ### Be nice
 
-As evidenced by Erin Meyer’s [“The Cultural Map”
-book](https://erinmeyer.com/books/the-culture-map/), people from different
-cultural backgrounds have different ways of communicating. While we don’t expect
-you to be an expert in [“reading the
+As evidenced in [The Cultural Map](https://erinmeyer.com/books/the-culture-map/)
+by Erin Meyer, people from different cultural backgrounds have different ways of
+communicating. While we don’t expect you to be an expert in [“reading the
 air”](https://www.bbc.com/worklife/article/20200129-what-is-reading-the-air-in-japan),
 we expect that you be nice to other folks and that your communication is clear
 without requiring the other parties to infer what’s not explicitly written


### PR DESCRIPTION
This PR improves our code of conduct by stating how violations should be reported. It also adds a set of community values, showing what we expect from our community members when interacting with other members.

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>
