### PR TITLE
Discussions are opt in, maintainers responsible for moderation

### DIFF
--- a/docs/how-to-configure-new-repository.md
+++ b/docs/how-to-configure-new-repository.md
@@ -22,6 +22,13 @@ Everything not mentioned is left at the GitHub default.
 * Automatically delete head branches: :heavy_check_mark:
   * (so that merged branches are not left lying around)
 
+**A note on discussions**: Discussions are disabled by default when creating a
+new repository. Maintainers may enable discussions, but in doing so take on the
+responsibility of moderating conversations in accordance with
+the [code of conduct](../code-of-conduct.md). Maintainers who enable discussions
+are encouraged to configure the discussion categories to suit their needs, e.g.
+by removing categories which overlap with issues.
+
 ### Collaborators and Teams
 
 * Every repository has three teams associated with it. Typically for the


### PR DESCRIPTION
In the 10/25 TC meeting we discussed the github discussions feature:

* Should discussions be enabled in any opentelemetry repository?
* What is the value of / difference between discussions and issues?
* What is the value of / difference between discussions and other Q&A forums like CNCF slack and Stackoverflow?

The conclusions were:

* Discussions often overlap with issues - i.e. often discussions are feature requests in disguise.
* We shouldn't have discussions which are unchecked and unmoderated. This invites unhealthy conversation we want to discourage.
* Some communities like `opentelemetry-dotnet` have been using discussions quite affectively and we shouldn't be restrictive about their use when helpful.

This PR adds a note to the repository setup instructions about discussions, clarifying that they should be disabled by default, but that maintainers can opt in if they moderate.