### PR TITLE
chore: unpin version of markdown-link-check

### DIFF
--- a/.github/workflows/reusable-markdown-link-check.yml
+++ b/.github/workflows/reusable-markdown-link-check.yml
@@ -10,9 +10,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install markdown-link-check
-        # fix version to 3.10.3 as 3.11.0 appears to ignore --config, so we can't specify our own
-        # configuration file
-        run: npm install -g markdown-link-check@3.10.3
+        run: npm install -g markdown-link-check@3
 
       - name: Run markdown-link-check
         run: |


### PR DESCRIPTION
The config issue was fixed in v3.11.1: https://github.com/tcort/markdown-link-check/releases/tag/v3.11.1.

I have verified locally that it works correctly.