### PR TITLE
Add docs responsibilites to approvers and maintainers

### DIFF
--- a/community-membership.md
+++ b/community-membership.md
@@ -161,6 +161,7 @@ approver in the `CODEOWNERS` files.
 - Responsible for project quality control via code reviews
   - Focus on holistic acceptance of contribution such as dependencies with other
     features, backwards / forwards compatibility, API and flag definitions, etc
+- Responsible for technical quality control of the [documentation](http://docs.opentelemetry.io/), related to their project
 - Expected to be responsive to review requests (inactivity for more than 1 month may result in suspension until active again)
 - Mentor contributors and reviewers
 - May approve code contributions for acceptance
@@ -218,6 +219,7 @@ The following apply to the subproject for which one would be a maintainer.
 - Ensure continued health of subproject:
   - Adequate test coverage to confidently release
   - Tests are passing reliably (i.e. not flaky) and are fixed when they fail
+  - Up-to-date and accurate [documentation](http://docs.opentelemetry.io/)
 - Ensure a healthy process for discussion and decision making is in place.
 - Work with other maintainers to maintain the project's overall health and
   success holistically.


### PR DESCRIPTION
With documentation being effectively living outside of SIG repositories, I think it is important to highlight in the responsibilities of SIG approvers and maintainers, that they have shared ownership of the sections at docs.opentelemetry.io which are related to their sub-project

cc @open-telemetry/docs-approvers 

Note: Similar updates may be required for security practices (cc @open-telemetry/sig-security-maintainers)