### PR TITLE
Add an issue template for maintainer onboarding

### DIFF
--- a/.github/ISSUE_TEMPLATE/maintainer-onboarding.yml
+++ b/.github/ISSUE_TEMPLATE/maintainer-onboarding.yml
@@ -1,7 +1,7 @@
 name: Maintainer Onboarding
 description: Onboarding checklist for maintainers
 title: "Onboard <GitHub handle> as <SIG/WG FOO> maintainer"
-labels: area/github-membership
+labels: area/onboarding
 body:
 - type: markdown
   attributes:

--- a/.github/ISSUE_TEMPLATE/maintainer-onboarding.yml
+++ b/.github/ISSUE_TEMPLATE/maintainer-onboarding.yml
@@ -1,0 +1,81 @@
+name: Maintainer Onboarding
+description: Onboarding checklist for maintainers
+title: "Onboard <GitHub handle> as <SIG/WG FOO> maintainer"
+labels: area/github-membership
+body:
+- type: markdown
+  attributes:
+    value: |
+     This issue should be submitted by an existing maintainer of the affected SIG
+- id: sig
+  type: input
+  attributes:
+    label: "SIG name"
+    placeholder: "SIG example"
+  validations:
+    required: true
+- id: maintainers_group
+  type: input
+  attributes:
+    label: "maintainers team"
+    placeholder: "@opentelemetry/<sig-name>-maintainers"
+    description: Tag the maintainers group. If unsure, you can [look groups up](https://github.com/orgs/open-telemetry/teams?query=maintainers)
+  validations:
+    required: true
+- id: github_handle
+  type: input
+  attributes:
+    label: "Github handle of the new maintainer candidate"
+    placeholder: "@example"
+  validations:
+    required: true
+- id: requirements
+  type: checkboxes
+  attributes:
+    label: Requirements
+    description: Before submitting 
+    options:
+      - label: Are you (submitter of this issue) a maintainer of the affected SIG?
+        required: true
+      - label: Is the maintainer candidate a member of the OpenTelemetry GitHub organization already?
+        required: true
+- id: election
+  type: checkboxes
+  attributes:
+    label: Maintainer Election
+    description: |
+      Unless stated otherwise in a SIG charter ratified by the Technical Committee, all existing maintainers are asked to vote, 
+      if the candidate should be added to their group of maintainers. They vote by commenting "I support" or "I do not support" on this issue.
+      The election is over, when a majority of the maintainers have voted. If the majority have voted in favour of the candidate, the candidate 
+      can accept (or decline) the vote by commenting "I accept" or "I decline". If the candidate has not been elected, the issue can be closed.
+    options:
+      - label: Has the candidate been elected?
+      - label: Has the candidate accepted?
+- id: onboarding
+  type: checkboxes
+  attributes:
+    label: Maintainer Onboarding Tasks
+    description: |
+      After the maintainer has been elected, the following check list helps to verify that the maintainer has everything needed
+      to fullfil their responsibility.
+    options:
+      - label: Added to the `@opentelemetry/<sig-name>-maintainers` GitHub group
+      - label: Added to `#otel-maintainers` slack channel
+      - label: Added to the `maintainers` section in the SIGs repositories `README.md`
+      - label: Added to [opentelemetry-calendar-contributors Google Group](https://groups.google.com/g/opentelemetry-calendar-contributors) 
+      - label: Added to any other groups, slack channels or resources that SIG maintainers require
+      - label: Invited to SIG meetings and Maintainer meeting.
+- id: tasks
+  type: checkboxes
+  attributes:
+    label: Prerequisites for new maintainer
+    description: |
+      The maintainer is asked to review the following checklist, fullfil the items and check them off. When all items of this list are completed, this issue can be closed
+    options:
+      - label: Completed all **Maintainer Onboarding Tasks** (see above)
+      - label: Reviewed the [Code of Conduct](./code-of-conduct.md)
+      - label: Reviewed [requirements, responsibilites and privileges](./community-membership.md#maintainer)
+      - label: Reviewed [mission, vision, values](./mission-vision-values.md)
+      - label: Reviewed all SIG specific documents that are relevant for a maintainer
+      - label: Scheduled a introductory call (30-60 minutes) with a GC member
+      - label: Completed the [Inclusive Open Source Community Orientation course](https://training.linuxfoundation.org/training/inclusive-open-source-community-orientation-lfc102/)

--- a/community-membership.md
+++ b/community-membership.md
@@ -227,18 +227,22 @@ The following apply to the subproject for which one would be a maintainer.
 ### Becoming a Maintainer
 
 Unless stated otherwise in a SIG charter ratified by the Technical Committee,
-a new maintainer is elected by vote of the existing maintainers of the SIG.
-The vote is officially started when a pull request to add a new maintainer
-is opened, and ends when the pull request is merged. The pull request may be
-merged when the following conditions are met:
+a new maintainer is elected by vote of thee existing maintainers of the SIG.
+The vote is officially started when an 
+[issue is created](https://github.com/open-telemetry/community/issues/new?assignees=&labels=area%2Fonboarding&template=maintainer-onboarding.yml&title=Maintainer+Onboarding%3A+%3CGH_USERNAME%3E)
+to add the nominee as a new maintainer. All existing maintainers of the SIG 
+are asked to vote by commenting "I support" or "I do not support" on this issue. 
+The election is over, when a majority of the maintainers have voted:
 
-- The person being nominated has accepted the nomination by approving the pull request
-- All maintainers have approved the pull request OR a majority of maintainers
-  have approved the pull request and no maintainer has objected by requesting
-  changes on the pull request. In the case that all maintainers have not given
-  approval, the pull request should stay open for a minimum of 5 days before merging.
+- If the majority have voted in favour of the nominee, the candidate accepts
+(or declines) the vote by commenting "I accept" or "I decline". The nominee is
+considered a maintainer immediatly after they accepted.
+- If the majority have voted against the nominee becoming a maintainer, the
+issue can be closed and the nominee has not been elected.
 
-The nominee is considered a maintainer after the pull request is merged.
+In the case that no majority in favour or against the nominee can be accomplished
+within 5 days, a minority vote sufficies.
+
 
 #### Self-nomination is encouraged
 


### PR DESCRIPTION
This PR introduces a dedicated issue template to elect and onboard a new [maintainer](https://github.com/svrnm/community/blob/maintainer-onboarding-issue-template-1/community-membership.md#maintainer).

Preview: https://github.com/svrnm/community/issues/new?assignees=&labels=area%2Fgithub-membership&projects=&template=maintainer-onboarding.yml&title=Onboard+%3CGitHub+handle%3E+as+%3CSIG%2FWG+FOO%3E+maintainer

# Problem

[the current process to elect maintainers](https://github.com/svrnm/community/blob/maintainer-onboarding-issue-template-1/community-membership.md#becoming-a-maintainer) has [never(?) been applied](https://github.com/open-telemetry/community/pulls?q=is%3Apr+maintainer), and since the list of maintainers & approvers lives mainly in the [SIG repos now](https://github.com/svrnm/community/blob/maintainer-onboarding-issue-template-1/community-members.md) (_"The list of active members (both "approvers" and "maintainers") for the <SIG> can be found in the <repo> README file"_) it also does not match the requirements anymore. 

Unfortunately, by only updating those files in the repo (or updating the github teams) the community does not hear about new maintainers stepping up. This makes it hard for cross-functional SIGS (Comms, EUWG, security, demo) to know who the maintainers are and also the TC&GC has no full visiblity into that, making it hard to judge from the outside if a SIG has a healthy set of maintainers. Finally, we (the OpenTelemetry community) should treat an individual stepping up as a maintainer as a highlight, that should be visible and recognized. 

# Solution

By introducing an onboarding issue for maintainers we can address all those needs, and at the same time also accomplish a few additional things, like having checklists for existing maintainers and new maintainers, or being able to introduce same additional rituals (e.g. introducing an informal chat between a new maintainer and a GC member to welcome them)

Please, take a look at this PR. I added a lot of additional _features_, that may not be wanted, so I expect this file to shrink, and there may be things I missed, so it might grow.  

# Other details

* Similar to this we may consider introducing onboarding for other community roles (approvers), because I also think the community should know about them to have a chance to recognize the individuals.
* If we implement #1793 we could go back to the "PR process" we have right now, but I argue this should simply become an item on that checklist.
* Thanks to @danielgblanco for creating the [GC member onboarding issue template](https://github.com/open-telemetry/community/blob/main/.github/ISSUE_TEMPLATE/gc_member_onboarding.md), which was really helpful to get this one done.