### PR TITLE
Add community activities to membership requirements

### DIFF
--- a/.github/ISSUE_TEMPLATE/membership.md
+++ b/.github/ISSUE_TEMPLATE/membership.md
@@ -37,4 +37,5 @@ Please remember, it is an applicant's responsibility to get their sponsors' conf
 
 - PRs reviewed / authored
 - Issues responded to
+- Community activities I organized/ran
 - SIG projects I am involved with

--- a/community-membership.md
+++ b/community-membership.md
@@ -49,6 +49,7 @@ Defined by: Member of the OpenTelemetry GitHub organization
   may include, but is not limited to:
   - Authoring or reviewing PRs on GitHub
   - Filing or commenting on issues on GitHub
+  - Organizing and running activities (e.g. events, surveys) within the OpenTelemetry community
   - Contributing to SIGs, subprojects, or community discussions (e.g. meetings,
     chat, email, and discussion forums)
 - [Joined the Slack channel](https://cloud-native.slack.com/archives/CJFCJHG4Q)


### PR DESCRIPTION
This updates the membership requirements to reflect that we have SIGs who express their contributions to the community outside of GitHub, and especially by organizing activities.

I think there are other parts of that document that require refinement but this is a starting point