### PR TITLE
Add pellared as log approver

### DIFF
--- a/.cspell.yaml
+++ b/.cspell.yaml
@@ -165,6 +165,7 @@ words:
     - otep
     - otlp
     - paixão
+    - pająk
     - parsana
     - passcodes
     - patrickhousley

--- a/.cspell.yaml
+++ b/.cspell.yaml
@@ -131,6 +131,7 @@ words:
     - otep
     - otlp
     - paixão
+    - pająk
     - passcodes
     - poncelow
     - proto

--- a/community-members.md
+++ b/community-members.md
@@ -61,6 +61,7 @@ Logs Approvers:
 
 - [Christian Beedgen](https://github.com/kumoroku), Sumo Logic
 - [Daniel Jaglowski](https://github.com/djaglowski), observIQ
+- [Robert Pająk](https://github.com/pellared), Splunk
 
 Logs Approvers Emeritus:
 


### PR DESCRIPTION
@pellared has been very actively contributing and driving log spec improvements (https://github.com/open-telemetry/opentelemetry-specification/pulls/pellared)