### PR TITLE
Add Liudmila Molkova to the TC.

### DIFF
--- a/areas-of-interest.md
+++ b/areas-of-interest.md
@@ -64,6 +64,12 @@ concerns.
 - Protocol compatibility (OpenCensus, Prometheus, Statsd, etc.)
 - Semantic conventions
 
+### [Liudmila Molkova](https://github.com/lmolkova), Microsoft
+
+- Trace API and SDK
+- Semantic conventions
+- Instrumentation
+
 ### [Reiley Yang](https://github.com/reyang), Microsoft
 
 - Logging API and SDK

--- a/community-members.md
+++ b/community-members.md
@@ -28,6 +28,7 @@ in alphabetical order:
 - [Jack Berg](https://github.com/jack-berg), New Relic
 - [Josh MacDonald](https://github.com/jmacd), Lightstep
 - [Josh Suereth](https://github.com/jsuereth), Google
+- [Liudmila Molkova](https://github.com/lmolkova), Microsoft
 - [Reiley Yang](https://github.com/reyang), Microsoft
 - [Tigran Najaryan](https://github.com/tigrannajaryan), Splunk
 - [Yuri Shkuro](https://github.com/yurishkuro), Meta


### PR DESCRIPTION
Following the current guidelines, we are adding Liudmila Molkova to the TC. 

* Liudmila has been a very active OTel member (namely in the Specification and in Semantic Conventions), helping drive conversations and sponsoring different groups (Http, Messaging, Databases and LLM).
* Liudmila's specific Instrumentation knowledge and experience will help the TC to have a more complete coverage of the ecosystem.
* Bogdan Drutu and Armin Ruech sponsored her nomination.
* The TC voted to add Liudmila as a new member, with the GC confirming the addition.  

cc @open-telemetry/governance-committee @open-telemetry/technical-committee 