### PR TITLE
Update .NET Auto-Instrumentation header

### DIFF
--- a/community-members.md
+++ b/community-members.md
@@ -90,7 +90,7 @@ Repo: [open-telemetry/opentelemetry-dotnet](https://github.com/open-telemetry/op
 
 The [list of active members](https://github.com/open-telemetry/opentelemetry-dotnet#contributing) (both "approvers" and "maintainers") can be found in the [README.md](https://github.com/open-telemetry/opentelemetry-dotnet/blob/master/README.md#contributing) file in the [repo](https://github.com/open-telemetry/opentelemetry-dotnet).
 
-### Auto-Instrumentation Agent (aka Tracer)
+### .NET Auto-Instrumentation
 
 Repo: [open-telemetry/opentelemetry-dotnet-instrumentation](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation).
 


### PR DESCRIPTION
We are trying to avoid both Agent (it can be misleading in .NET context, it is Java term) and Tracer (Metrics, Logs, (profiles)) are also supported by https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation