### PR TITLE
Add mention of open-telemetry-private in assets

### DIFF
--- a/assets.md
+++ b/assets.md
@@ -45,6 +45,8 @@ Link: https://grafana.com/orgs/otelsigsecurity
 - Users: SIG-Security Maintainers, Technical and Governance Committees
 - Admins: Juraci Paixão Kröhling @jpkrohling & Armin Ruech @arminru
 
+The GitHub organization `open-telemetry-private` also exists for this purpose.
+
 ## Artifact repositories
 
 ### NuGet OpenTelemetry organization


### PR DESCRIPTION
The Security SIG, along with the GC and TC, owns the GitHub organization `open-telemetry-private`, used store confidential information gathered by a privileged script. This organization wasn't mentioned before, and this PR fixes that.

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>
