### PR TITLE
Suggest to write PR descriptions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -183,6 +183,7 @@ Common new contributor PR issues are:
   introduce
 - Introducing change that should be first be approved by TC, for instance, the
   introduction of new terminology
+- Leaving the description blank or only including an issue number.
 
 ## Code Review
 


### PR DESCRIPTION
I see this pattern, and while I'm not a fan of very strict formatting, PRs should always at least say what they are doing, and why if they are non-trivial.