### PR TITLE
Update `community-membership.md` links

### DIFF
--- a/.github/ISSUE_TEMPLATE/membership.md
+++ b/.github/ISSUE_TEMPLATE/membership.md
@@ -16,7 +16,7 @@ e.g. (at)example_user
 
 ### Requirements
 
-- [ ] I have reviewed the community membership guidelines (https://github.com/open-telemetry/community/blob/main/community-membership.md)
+- [ ] I have reviewed the community membership guidelines (https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md)
 - [ ] I have enabled 2FA on my GitHub account. See https://github.com/settings/security
 - [ ] I have subscribed to the [Slack channel](https://cloud-native.slack.com/archives/CJFCJHG4Q) (use https://slack.cncf.io/ to get an invite)
 - [ ] I am actively contributing to 1 or more OpenTelemetry subprojects

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,7 +5,7 @@
 #####################################################
 #
 # Learn about membership in OpenTelemetry community:
-#  https://github.com/open-telemetry/community/blob/master/community-membership.md
+#  https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md
 #
 #
 # Learn about CODEOWNERS file format:

--- a/community-members.md
+++ b/community-members.md
@@ -46,7 +46,7 @@ Members of the Technical Committee are the maintainers of
 [Project specs](https://github.com/open-telemetry/opentelemetry-specification)
 and [Proto definitions](https://github.com/open-telemetry/opentelemetry-proto).
 
-[Specification sponsors](./community-membership.md#specification-sponsor) are
+[Specification sponsors](./guides/contributor/membership.md#specification-sponsor) are
 trusted collaborators of the Technical Committee on Project specs and related
 repositories:
 

--- a/community-membership.md
+++ b/community-membership.md
@@ -1,0 +1,3 @@
+This document was moved here:
+
+https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md

--- a/elections/2021/governance-committee-candidates.md
+++ b/elections/2021/governance-committee-candidates.md
@@ -198,7 +198,7 @@ Ilan Rabinovitch leads the community and product teams at Datadog. He spends his
 - Github: [punya](https://github.com/punya)
 
 
-I’ve participated in the OpenTelemetry community for the past year, especially the Go and Collector SIGs. In addition to writing code, I help clarify contentious designs and onboard new contributors. As a [triager](../../community-membership.md#triager) for the collector repository, I help our busy maintainers and contributors to use their time efficiently.
+I’ve participated in the OpenTelemetry community for the past year, especially the Go and Collector SIGs. In addition to writing code, I help clarify contentious designs and onboard new contributors. As a [triager](../../guides/contributor/membership.md#triager) for the collector repository, I help our busy maintainers and contributors to use their time efficiently.
 
 Before getting involved in telemetry, I led teams at small-to-midsize companies that were shipping products and figuring out observability for the first time. I’d like to use the perspective I gained from that experience to advocate for simple designs that are easy for newcomers and small teams to adopt.
 

--- a/guides/contributor/README.md
+++ b/guides/contributor/README.md
@@ -54,7 +54,7 @@ environment.
 
 - Review the [Mission, Vision, and Values](../../mission-vision-values.md) to
   understand the goals of the project.
-- Read the [Community Membership](../../community-membership.md) to understand
+- Read the [Community Membership](./membership.md) to understand
   the roles and responsibilities of the community.
 - As you gain experience, we encourage you to move up the ladder from member to
   triager, approver, and maintainer!

--- a/project-template.md
+++ b/project-template.md
@@ -41,7 +41,7 @@ Issues should be properly labeled to indicate what parts of the specification it
 
 Once approved, a project should be managed using a GitHub project board (see [open projects](https://github.com/orgs/open-telemetry/projects?query=is%3Aopen)). This project board should be pre-populated with issues that cover all known deliverables, organized by timeline milestones.
 
-Any [member](https://github.com/open-telemetry/community/blob/main/community-membership.md) associated with the project can create the board. Once created, the creator of the board should:
+Any [member](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md) associated with the project can create the board. Once created, the creator of the board should:
 
 - Assign `Admin` privileges on the project to the relevant project members (using a new or existing GitHub team).
 - Change the visibility of the project to `Public` in order to share project status and priorities outside of the OpenTelemetry organization.

--- a/tech-committee-charter.md
+++ b/tech-committee-charter.md
@@ -104,7 +104,7 @@ For all votes, a simple majority of a quorum of TC members for, or against, the 
 
 ### Requesting a TC decision
 
-When a project issue fails to reach consensus, OpenTelemetry [community members](./community-membership.md#member) may request that the TC make a decision. If the issue falls under a project with assigned [approvers](./community-membership.md#approver) and / or [maintainers](./community-membership.md#maintainer), at least two of those members should agree to and coordinate requesting a TC decision.
+When a project issue fails to reach consensus, OpenTelemetry [community members](./guides/contributor/membership.md#member) may request that the TC make a decision. If the issue falls under a project with assigned [approvers](./community-membership.md#approver) and / or [maintainers](./community-membership.md#maintainer), at least two of those members should agree to and coordinate requesting a TC decision.
 
 The request for a TC decision must be made by a comment on a public issue. The comment must explicitly tag the TC team (@open-telemetry/technical-committee), and summarize the various options and their relative tradeoffs. A TC member should review the summary and may request additional details or other changes to more accurately frame the issue. The request will then be added to the TC agenda, and the TC will work towards a decision using the [TC voting process](#voting-on-project-issues).
 
@@ -112,6 +112,6 @@ The request for a TC decision must be made by a comment on a public issue. The c
 
 The OpenTelemetry project git repository is maintained by the TC and additional Maintainers who are added by the TC on an ongoing basis.
 
-Individuals making significant and valuable contributions, can move through the project to leadership roles as outlined in the [Community Membership](./community-membership.md) document. Modifications of the contents of the git repository are made on a collaborative basis as defined in the development process.
+Individuals making significant and valuable contributions, can move through the project to leadership roles as outlined in the [Community Membership](./guides/contributor/membership.md) document. Modifications of the contents of the git repository are made on a collaborative basis as defined in the development process.
 
 Project Members may opt to elevate (via [mail list](./#tc-technical-committee)) significant or controversial modifications, or modifications that have not found consensus to the TC for discussion. The TC will serve as the final arbiter where required. The TC will additionally publish and maintain a development process guide for people looking to participate in the development effort.


### PR DESCRIPTION
The `community-membership.md` document [was recently moved to a new location](https://github.com/open-telemetry/community/pull/2051), but a lot of links to it weren't updated in the process. In this PR I:

- fix up links to it within this repository
- add a tombstone/redirect document as a stop-gap until the links in the [94 other places](https://github.com/search?q=org%3Aopen-telemetry%20community-membership.md&type=code) referencing the document across many different repos in the OTel organization are all fixed, to avoid sending people into a 404