### PR TITLE
Add required status checks for PRs

### DIFF
--- a/.github/repository-settings.md
+++ b/.github/repository-settings.md
@@ -14,6 +14,10 @@ settings](../docs/how-to-configure-new-repository.md#repository-settings).
 
 * Required number of approvals before merging: `2`
 * Require conversation resolution before merging: :heavy_check_mark:
+* Status checks that are required:
+  * EasyCLA
+  * spelling-check
+  * table-check
 
 ### `**/**`
 


### PR DESCRIPTION
I noticed this because after clicking "Update Branch" on a PR with auto-merge enabled, it is merged right away (not waiting for the checks to run).

I intentionally didn't add `markdown-link-check` since it can be flaky when checking external links.

I have updated the repo settings already (so I don't forget), but I'll revert them if needed.