### PR TITLE
Clarify members of standing

### DIFF
--- a/governance-charter.md
+++ b/governance-charter.md
@@ -1,6 +1,6 @@
 # OpenTelemetry Governance Committee Charter
 
-Last updated: December 2023
+Last updated: September 2024
 
 ## Overview
 
@@ -109,8 +109,8 @@ years and 5 seats in odd years).
 
 Members of Standing in the OpenTelemetry community are defined by the union of:
 
-- Active members - those with 20 contributions (PRs, Issues, Comments etc.) in
-  the prior rolling year.
+- Active contributors to the open-telemetry GitHub org - those with 20 contributions
+  (PRs, Issues, Comments etc.) in the prior rolling year.
 - All approvers, and maintainers in the OpenTelemetry organization
 
 Members who don’t meet either criteria above and are part of the following are


### PR DESCRIPTION
I misunderstood that a member of standing was a member of the open-telemetry org, when it is actually based on contributors to it. In other words, you do not need to become a member to vote.

Using the word member to define a member was confusing to me as we also define member elsewhere. There, we say that member is a part of the org, and that takes process besides contributions. https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#member

According to @jpkrohling
> member of standing is also independent: it's sufficient to have a minimum set of contributions, being a member or not