### PR TITLE
Add 'people to contact' to project template

### DIFF
--- a/project-template.md
+++ b/project-template.md
@@ -20,7 +20,7 @@ In general, OTEPs are not accepted unless they come with working prototypes avai
 
 Who is currently planning to work on the project? If a project requires specialized domain expertise, please list it here. If a project is missing a critical mass of people in order to begin work, please clarify.
 
-### People to contact
+### Industry outreach
 
 Who (people, companies) in the industry should be aware of this effort? Was there an attempt to get them onboard? What did they say?
 

--- a/project-template.md
+++ b/project-template.md
@@ -20,6 +20,10 @@ In general, OTEPs are not accepted unless they come with working prototypes avai
 
 Who is currently planning to work on the project? If a project requires specialized domain expertise, please list it here. If a project is missing a critical mass of people in order to begin work, please clarify.
 
+### People to contact
+
+Who (people, companies) in the industry should be aware of this effort? Was there an attempt to get them onboard? What did they say?
+
 ### Required staffing
 
 Projects cannot be started until the following participants have been identified:


### PR DESCRIPTION
This PR proposes a new section to the project template, requesting project proponents to identify the relevant people in the industry for this SIG. This would help us map where potential gaps are, and document who was invited to collaborate but refused. I believe this is very important to keep the new SIG process transparent.

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>

