### PR TITLE
Add K8s project board link

### DIFF
--- a/projects/k8s-semconv.md
+++ b/projects/k8s-semconv.md
@@ -87,6 +87,8 @@ and it should be relatively short we only need to update conformance to the spec
 
 **GC liaison:**
 
+- TBA
+
 **SemConv Maintainers:**
 
 - @open-telemetry/semconv-k8s-approvers
@@ -102,7 +104,7 @@ and it should be relatively short we only need to update conformance to the spec
 
 ## Project Board
 
-TBA
+[K8s SemConv SIG project board](https://github.com/orgs/open-telemetry/projects/114)
 
 ## SIG Meetings and Other Info
 


### PR DESCRIPTION
Since the K8s SemConv SIG has been accepted, this is a follow up from https://github.com/open-telemetry/community/pull/2352 to add the link of the project board.