### PR TITLE
Add Daniel Dyla's heading to GC 2024 candidates

### DIFF
--- a/elections/2024/governance-committee-candidates.md
+++ b/elections/2024/governance-committee-candidates.md
@@ -54,6 +54,8 @@ Join me in shaping the future of OpenTelemetry. Together, we can build a robust 
 
 ---
 
+### Daniel Dyla
+
 ![Daniel Dyla](static/daniel-dyla.jpg)
 
 - Company: [Dynatrace](https://dynatrace.com)


### PR DESCRIPTION
Identified in https://github.com/open-telemetry/community/issues/2307, this fixes @dyladan's entry adding a missing headline.