### PR TITLE
Post-election changes to GC

### DIFF
--- a/.cspell.yaml
+++ b/.cspell.yaml
@@ -19,6 +19,7 @@ words:
     - Alff
     - Arize
     - Ashpole
+    - Baeyens
     - Collibra
     - Coralogix
     - DASD

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -12,4 +12,4 @@
 #  https://help.github.com/en/articles/about-code-owners
 #
 
-* @alolita @austinlparker @danielgblanco @dyladan @jpkrohling @mtwo @svrnm @tedsuo @trask
+* @alolita @austinlparker @danielgblanco @jpkrohling @mtwo @mx-psi @svrnm @tedsuo @trask

--- a/community-members.md
+++ b/community-members.md
@@ -6,15 +6,15 @@ This is the current Governance Committee, per the [Governance Committee
 Charter](https://github.com/open-telemetry/community/blob/master/governance-charter.md),
 in alphabetical order:
 
-- [Alolita Sharma](https://github.com/alolita), Apple, until October 2024
+- [Alolita Sharma](https://github.com/alolita), Apple, until October 2026
 - [Austin Parker](https://github.com/austinlparker), Honeycomb, until October 2025
-- [Daniel Dyla](https://github.com/dyladan), Dynatrace, until October 2024
 - [Daniel Gomez Blanco](https://github.com/danielgblanco), Skyscanner, until October 2025
 - [Juraci Paixão Kröhling](https://github.com/jpkrohling), Grafana Labs, until October 2025
-- [Morgan McLean](https://github.com/mtwo), Splunk, until October 2024
+- [Morgan McLean](https://github.com/mtwo), Splunk, until October 2026
+- [Pablo Baeyens Fernandez](https://github.com/mx-psi), Datadog, until October 2026
 - [Severin Neumann](https://github.com/svrnm), Cisco, until October 2025
 - [Ted Young](https://github.com/tedsuo), Lightstep, until October 2025
-- [Trask Stalnaker](https://github.com/trask), Microsoft, until October 2024
+- [Trask Stalnaker](https://github.com/trask), Microsoft, until October 2026
 
 ## Technical Committee
 
@@ -185,6 +185,7 @@ Repo: [open-telemetry/opentelemetry-demo](https://github.com/open-telemetry/open
 - [Ben Sigelman](https://github.com/bhs), until October 2023
 - [Bogdan Drutu](https://github.com/BogdanDrutu), until October 2023
 - [Constance Caramanolis](https://github.com/ccaraman), until October 2021
+- [Daniel Dyla](https://github.com/dyladan), until October 2024
 - [Liz Fong-Jones](https://github.com/lizthegrey), until October 2022
 - [Sarah Novotny](https://github.com/SarahNovotny), until October 2021
 - [Sergey Kanzhelev](https://github.com/SergeyKanzhelev), until October 2021


### PR DESCRIPTION
- Adds @mx-psi to current members
- Updates term for re-elected members
- Adds @dyladan to emeritus GC members