### PR TITLE
Update language on setting meeting timezones

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,8 +125,7 @@ SIG-specific GitHub discussions.
 
 > [!NOTE]
 > The meeting times in the tables below are given in 24-hour notation.
-> All meeting hours between 2pm and 1am UTC are in Pacific Time (PT), with Daylight Saving Time.
-> All meeting hours between 2am and 1pm UTC in UTC+8, without Daylight Saving Time.
+> Meetings are either in Pacific Time (PT), with Daylight Saving Time, or UTC+8, without Daylight Saving Time.
 
 <!-- sigs -->
 ### Specification SIGs

--- a/docs/how-to-handle-public-calendar.md
+++ b/docs/how-to-handle-public-calendar.md
@@ -43,9 +43,9 @@ otherwise synchronization to external calendars via the `calendar-*@opentelemetr
 The following details need to be set properly:
 
 - Title
-- Timeslot, with the right timezone set:
-  - All meeting hours between 2pm and 1am UTC are in Pacific Time (PT), with Daylight Saving Time.
-  - All meeting hours between 2am and 1pm UTC in UTC+8, without Daylight Saving Time.
+- Timeslot, using one of the following timezones:
+  - Pacific Time (PT), with Daylight Saving Time.
+  - UTC+8, without Daylight Saving Time.
 - Recurrence pattern (usually weekly or bi-weekly)
 - Location (see below for the Zoom links)
 - Description


### PR DESCRIPTION
Remove the requirement for meetings at certain times to be pinned to UTC+8.

Fixes https://github.com/open-telemetry/community/issues/2419