### PR TITLE
Nominate Josh MacDonald to be spec sponsor

### DIFF
--- a/community-members.md
+++ b/community-members.md
@@ -55,6 +55,7 @@ repositories:
 - [Cijo Thomas](https://github.com/cijothomas), Microsoft
 - [Daniel Dyla](https://github.com/dyladan), Dynatrace
 - [David Ashpole](https://github.com/dashpole), Google
+- [Josh MacDonald](https://github.com/jmacd), Microsoft
 - [Juraci Paixão Kröhling](https://github.com/jpkrohling), Grafana Labs
 - [Leighton Chen](https://github.com/lzchen), Microsoft
 - [Marc Alff](https://github.com/marcalff), Oracle


### PR DESCRIPTION
Given #2443, I nominate @jmacd to be added as a spec sponsor. 

Reminder on the process for [becoming a spec sponsor](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#becoming-a-specification-sponsor):

> Technical committee members nominate specification sponsors by opening a PR to the community repo to add the nominee to the specification sponsor list. The vote is officially started when a pull request is opened, and ends when the pull request is merged. The pull request may be merged when the following conditions are met:
> * The person being nominated has accepted the nomination by approving the pull request.
> * All TC members have approved the pull request or a majority of TC members have approved the pull request and no other TC member has objected by requesting changes on the pull request. In the case that all TC members have not given approval, the pull request should stay open for a minimum of 10 days before merging.

> The nominee is considered a specification sponsor after the pull request is merged. The merger should update the spec-sponsors team with the new member. 

The vote must stay open until at least November 29th, or until all TC members have given approval.

@open-telemetry/technical-committee please vote by approving / declining this PR. 