### PR TITLE
Refer to CNCF allowlist for 3rd-party licenses approved for inclusion in CNCF repos

### DIFF
--- a/guides/contributor/processes.md
+++ b/guides/contributor/processes.md
@@ -207,8 +207,8 @@ you will need to [retain the original copyright notice](https://github.com/cncf/
 
 Any contributed third-party code must originally be Apache 2.0-Licensed or must
 carry a permissive software license that is compatible when combining with
-Apache 2.0 License. At this moment, BSD and MIT are the only
-[OSI-approved licenses](https://opensource.org/licenses/alphabetical) known to be compatible.
+Apache 2.0 License. The CNCF maintains a list of licenses approved for inclusion
+in a CNCF codebase [here](https://github.com/cncf/foundation/blob/main/allowed-third-party-license-policy.md#approved-licenses-for-allowlist).
 
 If you make substantial changes to the third-party code, _prepend_ the contributed
 third party file with OpenTelemetry's copyright notice.

--- a/guides/contributor/processes.md
+++ b/guides/contributor/processes.md
@@ -207,8 +207,9 @@ you will need to [retain the original copyright notice](https://github.com/cncf/
 
 Any contributed third-party code must originally be Apache 2.0-Licensed or must
 carry a permissive software license that is compatible when combining with
-Apache 2.0 License. The CNCF maintains a list of licenses approved for inclusion
-in a CNCF codebase [here](https://github.com/cncf/foundation/blob/main/allowed-third-party-license-policy.md#approved-licenses-for-allowlist).
+Apache 2.0 License. The [CNCF Allowlist License Policy](https://github.com/cncf/foundation/blob/main/allowed-third-party-license-policy.md#cncf-allowlist-license-policy)
+describes the requirements for including third-party code in CNCF codebases,
+along with a list of approved compatible licenses.
 
 If you make substantial changes to the third-party code, _prepend_ the contributed
 third party file with OpenTelemetry's copyright notice.


### PR DESCRIPTION
This came up in https://github.com/open-telemetry/opentelemetry-js/pull/5305 which is looking to include some ISC-licensed code in opentelemetry-js.git.

Refs: https://github.com/open-telemetry/community/issues/2504


---

Some notes:
- The original "At this moment, BSD and MIT are the only OSI-approved licenses known to be compatible" language came from https://github.com/open-telemetry/community/pull/479
- There is this older issue https://github.com/open-telemetry/community/issues/649 that may be resolved with this change? /cc @tigrannajaryan 
- FWIW, the ASF maintains a list of licenses it "identifies the acceptable licenses for inclusion of third-party Open Source components in Apache Software Foundation products.": https://www.apache.org/legal/resolved.html   However, the CNCF lists is probably the better one to treat an authoritative.