### PR TITLE
[editorial] gen-ai: fix call-out markdown syntax

### DIFF
--- a/projects/gen-ai.md
+++ b/projects/gen-ai.md
@@ -1,6 +1,7 @@
 # Generative AI Observability
 
->[!IMPORTANT] This project extends LLM Semantic Conventions project
+> [!IMPORTANT]
+> This project extends LLM Semantic Conventions project
 
 ## Description
 


### PR DESCRIPTION
Before:

> <img width="561" alt="image" src="https://github.com/user-attachments/assets/8329033d-851f-4177-acf0-d9f23328a0a5" />

After:

> <img width="447" alt="image" src="https://github.com/user-attachments/assets/9c67c56f-3d59-412d-b471-0f9c5d883404" />


/cc @svrnm