### PR TITLE
Add network collector to community-members.md

### DIFF
--- a/community-members.md
+++ b/community-members.md
@@ -176,6 +176,12 @@ Repo: [open-telemetry/opentelemetry-swift](https://github.com/open-telemetry/ope
 
 The list of active members (both "approvers" and "maintainers") for the OpenTelemetry Swift API & SDK can be found in the [open-telemetry/opentelemetry-swift CONTRIBUTING file](https://github.com/open-telemetry/opentelemetry-swift/blob/main/CONTRIBUTING.md).
 
+## Network collector
+
+Repos: [open-telemetry/opentelemetry-network](https://github.com/open-telemetry/opentelemetry-network) and [open-telemetry/opentelemetry-network-build-tools](https://github.com/open-telemetry/opentelemetry-network-build-tools)
+
+The list of active members (both "approvers" and "maintainers") for OpenTelemetry Rust can be found in the [open-telemetry/opentelemetry-network README file](https://github.com/open-telemetry/opentelemetry-network/blob/main/README.md#contributing).
+
 ## Community Demo
 
 Repo: [open-telemetry/opentelemetry-demo](https://github.com/open-telemetry/opentelemetry-demo)

--- a/community-members.md
+++ b/community-members.md
@@ -180,7 +180,7 @@ The list of active members (both "approvers" and "maintainers") for the OpenTele
 
 Repos: [open-telemetry/opentelemetry-network](https://github.com/open-telemetry/opentelemetry-network) and [open-telemetry/opentelemetry-network-build-tools](https://github.com/open-telemetry/opentelemetry-network-build-tools)
 
-The list of active members (both "approvers" and "maintainers") for OpenTelemetry Rust can be found in the [open-telemetry/opentelemetry-network README file](https://github.com/open-telemetry/opentelemetry-network/blob/main/README.md#contributing).
+The list of active members (both "approvers" and "maintainers") for OpenTelemetry Network can be found in the [open-telemetry/opentelemetry-network README file](https://github.com/open-telemetry/opentelemetry-network/blob/main/README.md#contributing).
 
 ## Community Demo
 


### PR DESCRIPTION
Just noticed that the network collector repos are not referenced in community-members.md. Added the two repositories and a link to triagers/approvers/maintainers