### PR TITLE
Update links to projects board

### DIFF
--- a/.github/ISSUE_TEMPLATE/gc_member_onboarding.md
+++ b/.github/ISSUE_TEMPLATE/gc_member_onboarding.md
@@ -179,7 +179,7 @@ capacity, in finding answers to these questions.
 - [ ] [Active Projects](https://github.com/open-telemetry/community/tree/main/projects):
   to understand current project deliverables and the challenges they aim to
   solve.
-- [ ] [Project Board](https://github.com/orgs/open-telemetry/projects/29):
+- [ ] [Project Board](https://github.com/orgs/open-telemetry/projects/135):
   including the individual project boards for each of these, they help
   understand the current state of the projects listed in the previous item.
 - [ ] [Community repo docs](https://github.com/open-telemetry/community/tree/main/docs):

--- a/project-management.md
+++ b/project-management.md
@@ -32,7 +32,7 @@ Groups are encouraged to define deadlines for any work which will require public
 
 ## Project Lifecycle
 
-All projects progress through a lifecycle. Projects are tracked on the [Project Board](https://github.com/orgs/open-telemetry/projects/29), which the community can use to get a high-level view of the OpenTelemetry roadmap.
+All projects progress through a lifecycle. Projects are tracked on the [Project Board](https://github.com/orgs/open-telemetry/projects/135), which the community can use to get a high-level view of the OpenTelemetry roadmap.
 
 The project lifecycle is as follows:
 

--- a/projects/README.md
+++ b/projects/README.md
@@ -1,1 +1,1 @@
-This folder contains all OpenTelemetry projects which have been approved by the GC. Please see the [project board](https://github.com/orgs/open-telemetry/projects/29) for an overview of the state of every project.
+This folder contains all OpenTelemetry projects which have been approved by the GC. Please see the [project board](https://github.com/orgs/open-telemetry/projects/135) for an overview of the state of every project.


### PR DESCRIPTION
Updates links to the new [Projects](https://github.com/orgs/open-telemetry/projects/135/views/1) board which focuses solely on Projects, split from the original [Spec + OTEPs](https://github.com/orgs/open-telemetry/projects/29/views/6)