### PR TITLE
Add sponsorship requirements to the technical committee charter.

### DIFF
--- a/.cspell.yaml
+++ b/.cspell.yaml
@@ -208,6 +208,7 @@ words:
     - Quesma
     - raesene
     - reiley
+    - roadmaps
     - rolldice
     - ruech
     - runtimes

--- a/tech-committee-charter.md
+++ b/tech-committee-charter.md
@@ -68,7 +68,7 @@ The TC will establish and maintain sponsorship across the SIGs and subprojects o
 SIGs will be classified into three classifications of Sponsorship requirement:
 
 * *Escalation Sponsorship*: The TC sponsor will be a primary means of escalation of cross-project concerns from the SIG. This communication is primarily
-  offline, e.g. via CNCF slack or issue communication. The TC sponsor will participate in [GC check-ins](gc-check-ins.md) with SIG leadership.
+  offline, e.g. via CNCF Slack or issue communication. The TC sponsor will participate in [GC check-ins](gc-check-ins.md) with SIG leadership.
   Additionally, the TC will aide the SIG in developing road maps during this check-in, and aligning to overall OpenTelemetry goals.
 * *Guiding Sponsorship*: The TC sponsor is an active participant of the SIG. The sponsor will help direct the SIGs efforts to match the technical goals of OpenTelemetry.
 * *Leading Sponsorship*: The TC sponsor is an active member of SIG leadership, driving the direct success of the project or proposal.

--- a/tech-committee-charter.md
+++ b/tech-committee-charter.md
@@ -69,7 +69,7 @@ SIGs will be classified into three classifications of Sponsorship requirement:
 
 * *Escalation Sponsorship*: The TC sponsor will be a primary means of escalation of cross-project concerns from the SIG. This communication is primarily
   offline, e.g. via CNCF Slack or issue communication. The TC sponsor will participate in [GC check-ins](gc-check-ins.md) with SIG leadership.
-  Additionally, the TC will aide the SIG in developing roadmaps during this check-in, and aligning to overall OpenTelemetry goals.
+  Additionally, the TC sponsor will aid the SIG in developing roadmaps during this check-in, and aligning to overall OpenTelemetry goals.
 * *Guiding Sponsorship*: The TC sponsor is an active participant of the SIG. The sponsor will help direct the SIGs efforts to match the technical goals of OpenTelemetry.
 * *Leading Sponsorship*: The TC sponsor is an active member of SIG leadership, driving the direct success of the project or proposal.
 

--- a/tech-committee-charter.md
+++ b/tech-committee-charter.md
@@ -68,10 +68,14 @@ The TC will establish and maintain sponsorship across the SIGs and subprojects o
 SIGs will be classified into three classifications of Sponsorship requirement:
 
 * *Escalation Sponsorship*: The TC sponsor will be a primary means of escalation of cross-project concerns from the SIG. This communication is primarily
-  offline, e.g. via CNCF slack or issue communication. The TC sponsor will check-in with SIG leadership quarterly.  Additionally, the TC will aide the SIG
-  in developing quarterly road maps during this check-in.
+  offline, e.g. via CNCF slack or issue communication. The TC sponsor will participate in [GC check-ins](gc-check-ins.md) with SIG leadership.
+  Additionally, the TC will aide the SIG in developing road maps during this check-in, and aligning to overall OpenTelemetry goals.
 * *Guiding Sponsorship*: The TC sponsor is an active participant of the SIG. The sponsor will help direct the SIGs efforts to match the technical goals of OpenTelemetry.
 * *Leading Sponsorship*: The TC sponsor is an active member of SIG leadership, driving the direct success of the project or proposal.
+
+All SIGs within OpenTelemetry will be required to have some level of sponsorship requirement (at least *Escalation*). Higher level sponsorship automatically fulfills
+lower level sponsorship requirements, e.g. *Guiding* sponsorship fulfills an *Escalation* sponsorship requirement, as *Leading* sponsorship would fulfill an
+*Escalation* sponsorship requirement. Sponsorship is not exclusive. More than one TC member may sponsor a SIG.
 
 As part of their active leadership, every TC member will be required to sponsor SIGs across OpenTelemetry.
 

--- a/tech-committee-charter.md
+++ b/tech-committee-charter.md
@@ -69,7 +69,7 @@ SIGs will be classified into three classifications of Sponsorship requirement:
 
 * *Escalation Sponsorship*: The TC sponsor will be a primary means of escalation of cross-project concerns from the SIG. This communication is primarily
   offline, e.g. via CNCF Slack or issue communication. The TC sponsor will participate in [GC check-ins](gc-check-ins.md) with SIG leadership.
-  Additionally, the TC will aide the SIG in developing road maps during this check-in, and aligning to overall OpenTelemetry goals.
+  Additionally, the TC will aide the SIG in developing roadmaps during this check-in, and aligning to overall OpenTelemetry goals.
 * *Guiding Sponsorship*: The TC sponsor is an active participant of the SIG. The sponsor will help direct the SIGs efforts to match the technical goals of OpenTelemetry.
 * *Leading Sponsorship*: The TC sponsor is an active member of SIG leadership, driving the direct success of the project or proposal.
 

--- a/tech-committee-charter.md
+++ b/tech-committee-charter.md
@@ -74,8 +74,8 @@ SIGs will be classified into three classifications of Sponsorship requirement:
 * *Leading Sponsorship*: The TC sponsor is an active member of SIG leadership, driving the direct success of the project or proposal.
 
 All SIGs within OpenTelemetry will be required to have some level of sponsorship requirement (at least *Escalation*). Higher level sponsorship automatically fulfills
-lower level sponsorship requirements, e.g. *Guiding* sponsorship fulfills an *Escalation* sponsorship requirement, as *Leading* sponsorship would fulfill an
-*Escalation* sponsorship requirement. Sponsorship is not exclusive. More than one TC member may sponsor a SIG.
+lower level sponsorship requirements, e.g. *Guiding* sponsorship fulfills an *Escalation* sponsorship requirement, as *Leading* sponsorship would fulfill a
+*Guiding* sponsorship requirement. Sponsorship is not exclusive. More than one TC member may sponsor a SIG.
 
 As part of their active leadership, every TC member will be required to sponsor SIGs across OpenTelemetry.
 

--- a/tech-committee-charter.md
+++ b/tech-committee-charter.md
@@ -79,7 +79,7 @@ lower level sponsorship requirements, e.g. *Guiding* sponsorship fulfills an *Es
 
 As part of their active leadership, every TC member will be required to sponsor SIGs across OpenTelemetry.
 
-Every TC member is required to provide a minimum of one (1) *Escalation* sponsorship. All SIGs requiring escalation sponsorship will be divided across the TC.
+All SIGs requiring escalation sponsorship will be divided across the TC. Every TC member is required to provide a minimum of one (1) *Escalation* sponsorship. 
 
 Every TC member is required to provide a minimum of two (2) *Guiding* or *Leading* sponsorships.
 

--- a/tech-committee-charter.md
+++ b/tech-committee-charter.md
@@ -61,6 +61,30 @@ The development process will include a process for the TC to oversee and approve
 
 The TC and entire technical community will follow any processes as may be specified by the Cloud Native Computing Foundation relating to the intake and license compliance review of contributions, including the CNCF IP Policy.
 
+### Sponsorship Requirements
+
+The TC will establish and maintain sponsorship across the SIGs and subprojects of OpenTelemetry.
+
+SIGs will be classified into three classifications Sponsorship requirement:
+
+* *Escalation Sponsorship*: The TC sponsor will be a primary means of escalation of cross-project concerns from the SiG. This communication is primarily
+  offline, e.g. via CNCF slack or issue communication. The TC sponsor will check-in with SIG leadership quarterly.  Additionally, the TC will aide the SIG
+  in developing quarterly roadmaps during this check-in.
+* *Guiding Sponsorship*: The TC sponsor is an active participant of the SIG. The sponsor will help direct the SIGs efforts to match the technical goals of OpenTelemetry.
+* *Leading Sponsorship*: The TC sponsor is an active member of SIG leadership, driving the direct success of the project or proposal.
+
+As part of their active leadership, every TC member will be required to sponsor SIGs across OpenTelemetry.
+
+Every TC member is required to provide a  minimum of one (1) *Escalation* sponsorship. All SIGs requiring escalation sponsorship will be divided across the TC.
+
+Every TC member is required to provide a minimum of two (2) *Guiding* or *Leading* sponsorships.
+
+Every TC member is limited to a maximum of two (2) *leading* sponsorships. This is to keep OpenTelemetry efforts focused and reduce fragmented attention on
+core issues.
+
+A TC member may have a time where they are not meeting the minimum sponsorship requirement, e.g. when major efforts have acheived results, and new projects are being formulated.
+This time should not exceed a six month period.
+
 ### Code Donations
 
 From time to time, organizations may wish to donate existing code to

--- a/tech-committee-charter.md
+++ b/tech-committee-charter.md
@@ -75,7 +75,7 @@ SIGs will be classified into three classifications of Sponsorship requirement:
 
 As part of their active leadership, every TC member will be required to sponsor SIGs across OpenTelemetry.
 
-Every TC member is required to provide a  minimum of one (1) *Escalation* sponsorship. All SIGs requiring escalation sponsorship will be divided across the TC.
+Every TC member is required to provide a minimum of one (1) *Escalation* sponsorship. All SIGs requiring escalation sponsorship will be divided across the TC.
 
 Every TC member is required to provide a minimum of two (2) *Guiding* or *Leading* sponsorships.
 

--- a/tech-committee-charter.md
+++ b/tech-committee-charter.md
@@ -79,7 +79,7 @@ Every TC member is required to provide a  minimum of one (1) *Escalation* sponso
 
 Every TC member is required to provide a minimum of two (2) *Guiding* or *Leading* sponsorships.
 
-Every TC member is limited to a maximum of two (2) *leading* sponsorships. This is to keep OpenTelemetry efforts focused and reduce fragmented attention on
+Every TC member is limited to a maximum of two (2) *Leading* sponsorships. This is to keep OpenTelemetry efforts focused and reduce fragmented attention on
 core issues.
 
 A TC member may have a time where they are not meeting the minimum sponsorship requirement, e.g. when major efforts have acheived results, and new projects are being formulated.

--- a/tech-committee-charter.md
+++ b/tech-committee-charter.md
@@ -67,7 +67,7 @@ The TC will establish and maintain sponsorship across the SIGs and subprojects o
 
 SIGs will be classified into three classifications of Sponsorship requirement:
 
-* *Escalation Sponsorship*: The TC sponsor will be a primary means of escalation of cross-project concerns from the SiG. This communication is primarily
+* *Escalation Sponsorship*: The TC sponsor will be a primary means of escalation of cross-project concerns from the SIG. This communication is primarily
   offline, e.g. via CNCF slack or issue communication. The TC sponsor will check-in with SIG leadership quarterly.  Additionally, the TC will aide the SIG
   in developing quarterly road maps during this check-in.
 * *Guiding Sponsorship*: The TC sponsor is an active participant of the SIG. The sponsor will help direct the SIGs efforts to match the technical goals of OpenTelemetry.

--- a/tech-committee-charter.md
+++ b/tech-committee-charter.md
@@ -65,11 +65,11 @@ The TC and entire technical community will follow any processes as may be specif
 
 The TC will establish and maintain sponsorship across the SIGs and subprojects of OpenTelemetry.
 
-SIGs will be classified into three classifications Sponsorship requirement:
+SIGs will be classified into three classifications of Sponsorship requirement:
 
 * *Escalation Sponsorship*: The TC sponsor will be a primary means of escalation of cross-project concerns from the SiG. This communication is primarily
   offline, e.g. via CNCF slack or issue communication. The TC sponsor will check-in with SIG leadership quarterly.  Additionally, the TC will aide the SIG
-  in developing quarterly roadmaps during this check-in.
+  in developing quarterly road maps during this check-in.
 * *Guiding Sponsorship*: The TC sponsor is an active participant of the SIG. The sponsor will help direct the SIGs efforts to match the technical goals of OpenTelemetry.
 * *Leading Sponsorship*: The TC sponsor is an active member of SIG leadership, driving the direct success of the project or proposal.
 

--- a/tech-committee-charter.md
+++ b/tech-committee-charter.md
@@ -63,7 +63,7 @@ The TC and entire technical community will follow any processes as may be specif
 
 ### Sponsorship Requirements
 
-The TC will establish and maintain sponsorship across the SIGs and subprojects of OpenTelemetry.
+The TC will establish and maintain sponsorship across OpenTelemetry SIGs.
 
 SIGs will be classified into three classifications of Sponsorship requirement:
 

--- a/tech-committee-charter.md
+++ b/tech-committee-charter.md
@@ -86,7 +86,7 @@ Every TC member is required to provide a minimum of two (2) *Guiding* or *Leadin
 Every TC member is limited to a maximum of two (2) *Leading* sponsorships. This is to keep OpenTelemetry efforts focused and reduce fragmented attention on
 core issues.
 
-A TC member may have a time where they are not meeting the minimum sponsorship requirement, e.g. when major efforts have acheived results, and new projects are being formulated.
+A TC member may have a time where they are not meeting the minimum sponsorship requirement, e.g. when major efforts have achieved results, and new projects are being formulated.
 This time should not exceed a six month period.
 
 ### Code Donations

--- a/tech-committee-charter.md
+++ b/tech-committee-charter.md
@@ -81,9 +81,10 @@ As part of their active leadership, every TC member will be required to sponsor 
 
 All SIGs requiring escalation sponsorship will be divided across the TC. Every TC member is required to provide a minimum of one (1) *Escalation* sponsorship. 
 
-Every TC member is required to provide a minimum of two (2) *Guiding* or *Leading* sponsorships.
+Every TC member is required to provide a minimum of at least three *Escalation* sponsorships and two *Guiding* sponsorships. Higher level sponsorship may be used to fulfill
+a lower level sponsorship requirement.
 
-Every TC member is limited to a maximum of two (2) *Leading* sponsorships. This is to keep OpenTelemetry efforts focused and reduce fragmented attention on
+Every TC member is limited to a maximum of two *Leading* sponsorships. This is to keep OpenTelemetry efforts focused and reduce fragmented attention on
 core issues.
 
 A TC member may have a time where they are not meeting the minimum sponsorship requirement, e.g. when major efforts have achieved results, and new projects are being formulated.

--- a/tech-committee-charter.md
+++ b/tech-committee-charter.md
@@ -79,10 +79,8 @@ lower level sponsorship requirements, e.g. *Guiding* sponsorship fulfills an *Es
 
 As part of their active leadership, every TC member will be required to sponsor SIGs across OpenTelemetry.
 
-All SIGs requiring escalation sponsorship will be divided across the TC. Every TC member is required to provide a minimum of one (1) *Escalation* sponsorship. 
-
-Every TC member is required to provide a minimum of at least three *Escalation* sponsorships and two *Guiding* sponsorships. Higher level sponsorship may be used to fulfill
-a lower level sponsorship requirement.
+All SIGs requiring escalation sponsorship will be divided across the TC. Every TC member is required to provide a minimum of at least three *Escalation* sponsorships
+and two *Guiding* sponsorships. Higher level sponsorship may be used to fulfill a lower level sponsorship requirement.
 
 Every TC member is limited to a maximum of two *Leading* sponsorships. This is to keep OpenTelemetry efforts focused and reduce fragmented attention on
 core issues.

--- a/tech-committee-charter.md
+++ b/tech-committee-charter.md
@@ -71,7 +71,7 @@ SIGs will be classified into three classifications of Sponsorship requirement:
   offline, e.g. via CNCF Slack or issue communication. The TC sponsor will participate in [GC check-ins](gc-check-ins.md) with SIG leadership.
   Additionally, the TC sponsor will aid the SIG in developing roadmaps during this check-in, and aligning to overall OpenTelemetry goals.
 * *Guiding Sponsorship*: The TC sponsor is an active participant of the SIG. The sponsor will help direct the SIGs efforts to match the technical goals of OpenTelemetry.
-* *Leading Sponsorship*: The TC sponsor is an active member of SIG leadership, driving the direct success of the project or proposal.
+* *Leading Sponsorship*: The TC sponsor is an active member of SIG leadership, responsible for driving the SIG's completion of charter goals.
 
 All SIGs within OpenTelemetry will be required to have some level of sponsorship requirement (at least *Escalation*). Higher level sponsorship automatically fulfills
 lower level sponsorship requirements, e.g. *Guiding* sponsorship fulfills an *Escalation* sponsorship requirement, as *Leading* sponsorship would fulfill a


### PR DESCRIPTION
## Summary

Updates the Technical Committee charter to qualify the phrase "The TC members are expected to be active leaders in the project" 

- Defines three classes of SIG sponsorship: _Escalation_, _Guiding_, _Leading_
- Adds requirements to TC members to participate in these sponsorships
  - At least one _Escalation_ sponsorship, with all SIGs having coverage across TC of this style sponsorship
  - At least two of _Guiding_ or _Leading_ sponsorship.
  - At most two of _Leading_ sponsorship.

## Background

The OpenTelemetry project has grown significantly over the past five years.  It has seen expansion into additional signals (logs, profiles) and rapid growth of project beyond just SDKs and Collectors (-contrib instrumentations, otlp-arrow, OpAMP, Weaver, Semantic Conventions, Kubernetes operator, etc. etc.).  The project now consists of over 80 github repositories and 600+ community members, with even more collaborators. 

The Technical committee has largely operated from initial momentum and traditions formed since its founding.  This helped streamline and stabilize the project through this growth, but recent issues have caused us to rethink our own structure and decide to clarify Technical Committee responsibilities.  We'd like to update the Technical Committee charter to ensure the following:

- Transparency
  - Technical Committee responsibilities are publicly documented and scale past any individual serving in the technical committee.
  - Expectations for serving on the Technical Committee are easy to understand.
- Growth and Size
  - OpenTelemetry Leadership is set up to grow and scale appropriate to the growth and scale of the project.
  - Solidify rationale and triggers for changes to TC membership size and shape.
- Decision Making Velocity
  - OpenTelemetry Technical decision making velocity must match the needs of the, now, much larger contributor base.
  - Ensuring appropriate representation of the OpenTelemetry community via sponsorships.

Out of scope for this proposal but something we will refine going forward:

- Solidify full expectations on participation from TC within OpenTelemetry
- Increasing transparency in how leadership is attained within OpenTelemetry
- Defining how the technical committee works and improving transparency in its execution.

Non-Goals of this proposal are:

- To define a complete rework of the TC charter. This is a step towards a better charter, but not the only step.
- To define what "TC Reviews" and Core Component Evaluations are. This task should be done in a separate, dedicated proposal.
- To refine how TC is selected, how community members are elevated to TC and when the TC size and structure should change.

## Success Criteria

This proposal is intended to improve the following:

- Enhanced communication of plans between SIGs and dedicated roles for ensuring technical issues are shared between SIGs.
- Provides natural limits on the number of active projects, via size of Technical Committee. This avoids the failure scenario of not having enough attention to drive solutions to key issues in SIGs.

Quantitatively, we think we can measure the following:

- The number of SIGs completing objectives in expected timelines.
- Improved Contributor Survey results.

