### PR TITLE
Use public project list instead of project board in links

### DIFF
--- a/.github/ISSUE_TEMPLATE/gc_member_onboarding.md
+++ b/.github/ISSUE_TEMPLATE/gc_member_onboarding.md
@@ -179,8 +179,7 @@ capacity, in finding answers to these questions.
 - [ ] [Active Projects](https://github.com/open-telemetry/community/tree/main/projects):
   to understand current project deliverables and the challenges they aim to
   solve.
-- [ ] [Project Board](https://github.com/orgs/open-telemetry/projects/135):
-  including the individual project boards for each of these, they help
+- [ ] [Projects](https://github.com/open-telemetry/community/projects?query=is%3Aopen):
   understand the current state of the projects listed in the previous item.
 - [ ] [Community repo docs](https://github.com/open-telemetry/community/tree/main/docs):
   for instructions on how to work with calendars, configuring repositories,

--- a/projects/README.md
+++ b/projects/README.md
@@ -1,1 +1,1 @@
-This folder contains all OpenTelemetry projects which have been approved by the GC. Please see the [project board](https://github.com/orgs/open-telemetry/projects/135) for an overview of the state of every project.
+This folder contains all OpenTelemetry projects which have been approved by the GC. Please see the [list of open projects](https://github.com/open-telemetry/community/projects?query=is%3Aopen) for an overview of their current state.


### PR DESCRIPTION
After https://github.com/open-telemetry/community/pull/2715 was merged, and before archiving the `Projects` project, this removes and dangling links.