### PR TITLE
Remove GitHub administration from Technical Committee charter

### DIFF
--- a/assets.md
+++ b/assets.md
@@ -53,7 +53,7 @@ This file is intended to list all the assets controlled by OpenTelemetry.
 
 Link: https://github.com/open-telemetry
 
-- Admins: [@open-telemetry/admins](https://github.com/orgs/open-telemetry/teams/admins
+- Admins: [@open-telemetry/admins](https://github.com/orgs/open-telemetry/teams/admins)
 
 ## Credential Storage
 

--- a/tech-committee-charter.md
+++ b/tech-committee-charter.md
@@ -37,7 +37,6 @@ The TC is responsible for all technical development within the OpenTelemetry pro
 * Setting release dates
 * Quality standards for releases
 * Technical direction
-* GitHub repository management, membership and hosting
 * Development process and any coding standards
 * Approving changes to any specifications
 * Mediating technical discussions which have cross project impact


### PR DESCRIPTION
As discussed in GC / TC meetings, we are moving GitHub administration over to @open-telemetry/admins (which is a smaller group with six members across both the GC and TC).

Also see #2749.