### PR TITLE
Add the Technical Committee as approvers for the community repo

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -12,4 +12,4 @@
 #  https://help.github.com/en/articles/about-code-owners
 #
 
-* @alolita @austinlparker @danielgblanco @jpkrohling @mtwo @mx-psi @svrnm @tedsuo @trask
+* @alolita @austinlparker @danielgblanco @jpkrohling @mtwo @mx-psi @svrnm @tedsuo @trask @open-telemetry/technical-committee


### PR DESCRIPTION
It was sort of obfuscated that they weren't already since everyone in the TC was a GitHub admin prior to #2749 which made their approvals carry green checkmarks.