### PR TITLE
Exclude historical docs from link checker

### DIFF
--- a/.lychee.toml
+++ b/.lychee.toml
@@ -15,6 +15,22 @@ exclude = [
     "^https://github.com/[^/]+$",
 ]
 
+exclude_path = [
+    # regular expressions aren't supported: https://github.com/lycheeverse/lychee/issues/1608
+    "/home/repo/elections/2019/governance-committee-candidates.md",
+    "/home/repo/elections/2019/governance-committee-election.md",
+    "/home/repo/elections/2020/governance-committee-candidates.md",
+    "/home/repo/elections/2020/governance-committee-election.md",
+    "/home/repo/elections/2021/governance-committee-candidates.md",
+    "/home/repo/elections/2021/governance-committee-election.md",
+    "/home/repo/elections/2022/governance-committee-candidates.md",
+    "/home/repo/elections/2022/governance-committee-election.md",
+    "/home/repo/elections/2023/governance-committee-candidates.md",
+    "/home/repo/elections/2023/governance-committee-election.md",
+    "/home/repo/elections/2024/governance-committee-candidates.md",
+    "/home/repo/elections/2024/governance-committee-election.md",
+]
+
 # Retry configuration with more reasonable timeout values
 max_retries = 3
 # Wait time (in seconds) between retries with exponential backoff

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -4,11 +4,6 @@ include_fragments = true
 accept = ["200..=299", "401", "403", "429"]
 
 exclude = [
-    "https://slack.com/help/articles/8328303095443-Understand-Channel-Managers-in-Slack",
-    "https://observe2020.io",
-    "https://servicenow.com",
-    "https://sched.co",
-    "https://srecon19emea.sched.com",
     # excluding links to user profiles is done for performance
     # because there are a lot of links to user profiles in this repository
     # and GitHub extra throttles access to user profile pages


### PR DESCRIPTION
Seems ok to leave these historical docs as-is and not try to keep the links up-to-date.