### PR TITLE
Remove opentelemetrybot write permission from new repo setup

### DIFF
--- a/docs/how-to-configure-new-repository.md
+++ b/docs/how-to-configure-new-repository.md
@@ -52,7 +52,6 @@ Teams should be granted proper permissions according to the following table:
 | open-telemetry/foo-maintainers      | Maintain |
 | open-telemetry/foo-triagers         | Triage   |
 | open-telemetry/governance-committee | Write    |
-| opentelemetrybot                    | Write    |
 
 If the repository is using the Project Boards, `foo-triagers` should have
 `Write` permissions to have access to the Project Boards. Do not add members of


### PR DESCRIPTION
We explicitly don't want to give opentelemetrybot this permissions

> [Important: You do not need to (and should not) give this account any permissions to any OpenTelemetry repository.](https://github.com/open-telemetry/community/blob/main/assets.md#opentelemetry-bot)