### PR TITLE
Update `**/**` branch protection rule

### DIFF
--- a/docs/how-to-configure-new-repository.md
+++ b/docs/how-to-configure-new-repository.md
@@ -159,7 +159,11 @@ repositories that are using merge queues.
 
 #### Branch protection rule: `**/**`
 
-Same as for [`main`](#branch-protection-rule-main) above.
+* Require status checks to pass before merging: :heavy_check_mark:
+  * Require branches to be up to date before merging: :heavy_check_mark:
+  * Status checks that are required:
+    * `EasyCLA`
+* Do not allow bypassing the above settings: :heavy_check_mark:
 
 ### Actions > General
 


### PR DESCRIPTION
This updates the documented `**/**` branch protection rule to match the one that is installed on repos by default by the CNCF enterprise org.