### PR TITLE
Create meeting recording policy

### DIFF
--- a/docs/how-meeting-recordings-upload-works.md
+++ b/docs/how-meeting-recordings-upload-works.md
@@ -33,7 +33,7 @@ Videos are being recorded using one of [zoom accounts](../assets.md#zoom-account
 
 - If older than 6 months, check the ['Zoom recordings archive' spreadsheet](https://docs.google.com/spreadsheets/d/1U34Ae4D8EMhMbrFujdSRjoHBae3o9pvptLO1c6X4RPI/edit?usp=sharing) for the meeting link.
 - Otherwise
-  - Find the zoom account corresponding to the meeting link. Mapping from static rooms to the account may be found in the zoom bombing document referred from [this page](../docs/how-to-handle-public-calendar.md#zoom-bombing-prevention).
+  - Find the zoom account corresponding to the meeting link. Mapping from static rooms to the account may be found in the zoom bombing document referred from [this page](../docs/how-to-handle-public-calendar.md#zoom-abuse-prevention).
   - If non OpenTelemetry zoom account was used, there will be no recording available. Please contact the owner of the zoom account linked from the event.
   - In the zoom account, check if the meeting recording present. If recording is there, it is a Zapier integration issue.
   - If recording is missing in zoom account, check the meeting room settings. Make sure that automatic meeting recording is enabled.

--- a/docs/how-to-handle-public-calendar.md
+++ b/docs/how-to-handle-public-calendar.md
@@ -105,7 +105,7 @@ Please open a community issue to request the creation of a `calendar-...@opentel
 
 All recurring meetings are listed in the [Community repo's README](../README.md#special-interest-groups), make sure to add/update the respective entry there.
 
-## Zoom bombing prevention
+## Zoom abuse prevention
 
 All meetings are created by Zoom with randomized passcodes, which are embedded into the shared calendar links.
 All members of [calendar-edit-permission@opentelemetry.io](https://groups.google.com/a/opentelemetry.io/g/calendar-edit-permission)

--- a/policies/third-party-meeting-recordings.md
+++ b/policies/third-party-meeting-recordings.md
@@ -3,4 +3,4 @@
 OpenTelemetry hosted meetings are recorded and transcribed by Zoom and made available for the convenience of the community ([details here](../docs/how-meeting-recordings-upload-works.md)).
 Third-party recording tools, note-taking apps, and other tools which record, transcribe, or otherwise process OpenTelemetry Zoom meetings are prohibited.
 This is to respect participants' privacy and ensure data governance by the OpenTelemetry Governance Committee rather than third-party companies and individuals.
-Maintainers should remove and block such tools using the process described in [Zoom abuse prevention](../docs/how-to-handle-public-calendar.md#zoom-abuse-prevention).
+Maintainers may remove and block such tools using the process described in [Zoom abuse prevention](../docs/how-to-handle-public-calendar.md#zoom-abuse-prevention).

--- a/policies/third-party-meeting-recordings.md
+++ b/policies/third-party-meeting-recordings.md
@@ -1,5 +1,6 @@
 # Third-party meeting recording policy
 
 OpenTelemetry hosted meetings are recorded and transcribed by Zoom and made available for the convenience of the community ([details here](../docs/how-meeting-recordings-upload-works.md)).
-Third party recording tools, note-taking apps, and other tools which record, transcribe, or otherwise process OpenTelemetry Zoom meetings are prohibited.
+Third-party recording tools, note-taking apps, and other tools which record, transcribe, or otherwise process OpenTelemetry Zoom meetings are prohibited.
+This is to respect participants' privacy and ensure data governance by the OpenTelemetry Governance Committee rather than third-party companies and individuals.
 Maintainers should remove and block such tools using the process described in [Zoom abuse prevention](../docs/how-to-handle-public-calendar.md#zoom-abuse-prevention).

--- a/policies/third-party-meeting-recordings.md
+++ b/policies/third-party-meeting-recordings.md
@@ -1,0 +1,5 @@
+# Third-party meeting recording policy
+
+OpenTelemetry hosted meetings are recorded and transcribed by Zoom and made available for the convenience of the community ([details here](../docs/how-meeting-recordings-upload-works.md)).
+Third party recording tools, note-taking apps, and other tools which record, transcribe, or otherwise process OpenTelemetry Zoom meetings are prohibited.
+Maintainers should remove and block such tools using the process described in [Zoom abuse prevention](../docs/how-to-handle-public-calendar.md#zoom-abuse-prevention).


### PR DESCRIPTION
Related #2681

Adds a policy that bans zoom bots and third party recorders.

It wasn't entirely clear to me where to document this policy. `docs`, `guides`, and `tools` directory all seem to provide how-to guides and explainers. The GC and TC charters definitely contain policies, but neither seemed a good fit for this. Similarly, the README has a `calendar` section but it is more focused on helping people find meetings than it is on policing them. I created a `policies` directory in order to clarify that this is a policy and not just a suggestion, and also to make it easy to find. If this should be documented somewhere else, please let me know and I'm happy to move it, however I think we should have a more clear distinction between what is a rule and what is a guide or suggestion anyway eventually.