### PR TITLE
Reword project management to adapt to existing SIGs

### DIFF
--- a/project-management.md
+++ b/project-management.md
@@ -1,36 +1,65 @@
 # Project Management
 
-The OpenTelemetry community has limited bandwidth for managing changes which expand the scope of OpenTelemetry, or impact many SIGs (Special Interest Groups) within OpenTelemetry.
+The OpenTelemetry community has limited bandwidth for managing work which expands the scope of OpenTelemetry, impacts many SIGs (Special Interest Groups) within OpenTelemetry, or becomes the main focus of any given SIG.
 
 These are common scenarios which have this kind of impact:
 
 * Non-trivial changes to the [OpenTelemetry Specification](https://github.com/open-telemetry/opentelemetry-specification).
 * Non-trivial changes to the [OpenTelemetry Semantic Conventions](https://github.com/open-telemetry/semantic-conventions).
-  * Non-trivial being: introducing new conventions, forming a new SIG around a subject, topic or technology and stabilization efforts.
-* A new SIG being formed.
+  * Non-trivial being: introducing new conventions, forming a new SIG around a subject, topic or technology, and stabilization efforts.
+* A new SIG being formed, focusing on a set of initial set of deliverables before stabilizing.
 * An existing SIG taking on new work which will affect the OpenTelemetry project as a whole, and will need review from the broader community.
+* An existing SIG working on a major roadmap item, which focuses their efforts for a specified length of time.
 
-Any changes which fall into one of the above categories must first create a project proposal and gain approval from the GC (Governance Committee) and TC (Technical Committee) before work begins.
+Any changes which fall into one of the above categories benefit from creating a project proposal and gaining approval from the GC (Governance Committee) and TC (Technical Committee) before work begins. In addition to gaining wider support from the community, projects also help increase awareness across the industry, encouraging participation and improving communication of roadmap items.
 
 The list of current projects, along with their most recent status, is available in our [community projects](https://github.com/open-telemetry/community/projects?query=is%3Aopen) page, which the community can use to get a high-level view of the OpenTelemetry roadmap. Project proposals currently under review can be tracked via their respective [open pull requests](https://github.com/open-telemetry/community/pulls?q=is%3Aopen+is%3Apr+label%3Aarea%2Fproject-proposal).
 
+## Relationship Between Projects and SIGs
+
+OpenTelemetry projects may either be carried out within the remit of existing SIGs, or require the creation of a new SIG to initially work on the deliverables outlined in a project proposal.
+
+A new SIG is generally required when the project expands the scope of OpenTelemetry, be it on specification, semantic conventions, or implementation. After the project is completed, the corresponding SIG may dissolve if the work delivered can be maintained by other existing SIGs going forward, or it may continue to operate and move onto other objectives.
+
+Special care should be put into defining the scope of a given project, especially when it requires a new SIG. A project is not synonymous to a SIG charter, so limiting the scope to an initial set of deliverables can avoid projects that never finish. 
+
+A project may also be created to signal a significant effort, or milestone, from one or more existing SIGs. As documented in the [project proposal](#project-proposal) section below, a project from an existing SIG requires significantly less logistics to get started, providing a way for SIGs to publicise their current milestones.
+
 ## Project Proposal
 
-At minimum, projects require the following resources to be successful:
+Projects require the following resources to be successful:
 
-* A clearly defined set of goals and deliverables.
+* A clearly defined set of problems to solve, goals, and deliverables.
 * Timelines for when the deliverables will be ready for review by the broader community.
-* Two TC/GC members, or community members delegated by them, to sponsor the project.
-  These two sponsors should be from different companies.
-* A group of designers and subject matter experts, dedicating a significant amount of their work time to the project. These participants are needed to design the spec, write a set of OTEPs, and create multiple prototypes. This group needs to meet with each other (and with their sponsors) on a regular basis to develop a successful set of proposals.
+* One or more existing SIGs that will work on this project, or the following required staffing if the project requires a new SIG:
+  * Project lead(s), who are willing to bottom line the project and address any issues which are not handled by other project members.
+    * These will ultimately become SIG maintainers, or approvers for semantic conventions SIGs.
+  * Sponsorship from OpenTelemetry leadership, see [Project Sponsorship](#project-sponsorship).
+  * If relevant to project:
+    * Engineers willing to write prototypes in at least two languages. Languages should be fairly different from each other, for example Java and Python.
+    * Maintainers or approvers from those languages committed to reviewing the prototypes.
 
-To propose a project, a**project document** must be created using the [project proposal template](project-template.md) as a guide. This document will be used as the initial proposal for the project.
+To propose a project, a **project document** must be created using the [project proposal template](project-template.md) as a guide. This document will be used as the initial proposal for the project.
 
 A project proposal can then be submitted by placing the project document in the [projects](projects/) folder and making a pull request against the community repo.
 
 As the project progresses, the project document should be kept up to date, and the community [README](README.md) should be updated to include any new project meeting information (see [contributing guide](https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md#updating-sig-information-on-the-readmemd)).
 
 Project leads are encouraged to define timelines for any work which will require public review, and to provide updates to the community in the form of [GitHub Project updates](https://docs.github.com/en/issues/planning-and-tracking-with-projects/learning-about-projects/sharing-project-updates). We have found that having scoped deliverables leads to an increased cadence in project work, and helps resolve debate. Timelines also help with getting a more coherent public review, as they allow the review community to plan on making themselves available. If timelines prove to be unrealistic, they can be always be updated.
+
+## Project Sponsorship
+
+All projects require sponsorship, ensuring those leading and working on the project are supported and set up for success.
+
+If a project is created as part of an existing SIG, the project lead(s), TC sponsor, and GC liaison of the project will correspond to the SIG maintainers, TC sponsor, and GC liaison.
+
+If a project involves the creation of a new SIG, it cannot be started until the following have been agreed:
+
+* A [TC](community-members.md#technical-committee) sponsor according to [TC sponsorship requirements](tech-committee-charter.md#sponsorship-requirements).
+  * In the case of semantic convention SIGs, [semantic convention maintainers](https://github.com/orgs/open-telemetry/teams/specs-semconv-maintainers) or community members delegated by them can act as sponsors, supported by a _TC Escalation Sponsor_.
+* A [GC](community-members.md#governance-committee) liaison to facilitate this SIG's health and ensure project scope remains true to the project description (see [GC check-ins](./gc-check-ins.md)).
+
+
 
 ## Project Lifecycle
 

--- a/project-management.md
+++ b/project-management.md
@@ -23,7 +23,7 @@ A new SIG is generally required when the project expands the scope of OpenTeleme
 
 Special care should be put into defining the scope of a given project, especially when it requires a new SIG. A project is not synonymous to a SIG charter, so limiting the scope to an initial set of deliverables can avoid projects that never finish. 
 
-A project may also be created to signal a significant effort, or milestone, from one or more existing SIGs. As documented in the [project proposal](#project-proposal) section below, a project from an existing SIG requires significantly less logistics to get started, providing a way for SIGs to publicise their current milestones.
+A project may also be created to signal a significant effort, or milestone, from one or more existing SIGs. As documented in the [project proposal](#project-proposal) section below, a project from an existing SIG requires significantly less logistics to get started, providing a way for SIGs to publicize their current milestones.
 
 ## Project Proposal
 

--- a/project-management.md
+++ b/project-management.md
@@ -7,7 +7,7 @@ These are common scenarios which have this kind of impact:
 * Non-trivial changes to the [OpenTelemetry Specification](https://github.com/open-telemetry/opentelemetry-specification).
 * Non-trivial changes to the [OpenTelemetry Semantic Conventions](https://github.com/open-telemetry/semantic-conventions).
   * Non-trivial being: introducing new conventions, forming a new SIG around a subject, topic or technology, and stabilization efforts.
-* A new SIG being formed, focusing on a set of initial set of deliverables before stabilizing.
+* A new SIG being formed, focusing on an initial set of deliverables before stabilizing.
 * An existing SIG taking on new work which will affect the OpenTelemetry project as a whole, and will need review from the broader community.
 * An existing SIG working on a major roadmap item, which focuses their efforts for a specified length of time.
 

--- a/project-template.md
+++ b/project-template.md
@@ -1,6 +1,8 @@
 # <<PROJECT NAME>>
 
-Name your project here. This should be a short, descriptive name that describes the main goal of the project, not the SIG that may be formed as part of it. For instance, if the project is aimed at the first set of deliverables for the Foo SIG, name the project "Foo SIG Bootstrap" or "Initial Foo Implementation".
+Name your project here. This should be a short, descriptive name that describes the main goal of the project, or the main deliverable, not the SIG that may be formed as part of it.
+
+For instance, if the project is aimed at the first set of deliverables for the Foo SIG, name the project "Foo SIG Bootstrap" or "Initial Foo Implementation", not "Foo SIG".
 
 ## Background and description
 
@@ -20,20 +22,35 @@ In general, OTEPs are not accepted unless they come with working prototypes avai
 
 ## Staffing / Help Wanted
 
-Who is currently planning to work on the project? If a project requires specialized domain expertise, please list it here. If a project is missing a critical mass of people in order to begin work, please clarify.
-
 ### Industry outreach
 
 Who (people, companies) in the industry should be aware of this effort? Was there an attempt to get them onboard? What did they say?
 
 ### Required staffing
 
-Projects cannot be started until the following participants have been identified:
-* Every project needs a project lead, who is willing to bottom line the project and address any issues which are not handled by other project members.
-* At least two sponsoring [TC](community-members.md#technical-committee) or [GC](community-members.md#governance-committee) members (or [semantic convention maintainers](https://github.com/orgs/open-telemetry/teams/specs-semconv-maintainers) in the case of semantic convention SIGs), or community members delegated by them. Sponsors are dedicated to attending meetings, reviewing proposals, and in general being aware of the state of the project and its technical details. Sponsors guide the project through the spec process, keep the tracking issue up to date, and help to ensure that relevant community members provide input at the appropriate times.
-* A GC liaison to facilitate this SIG's health and ensure project scope remains true to the project description. If a GC member is also a sponsor for this project, they are by default the GC liaison (see [GC check-ins](./gc-check-ins.md)).
-* Engineers willing to write prototypes in at least two languages (if relevant to project). Languages should be fairly different from each other (for example: Java and Python).
-* Maintainers or approvers from those languages committed to reviewing the prototypes.
+Who is planning to work on the project? If a project requires specialized domain expertise, please list it here. If an existing or new SIG is missing a critical mass of people in order to begin work, please clarify in the "other staffing" section below. See [project proposal](project-management.md#project-proposal) for more details.
+
+(For projects driven by existing SIGs)
+#### SIG(s)
+<SIG NAME>
+
+#### Other Staffing
+
+(For projects that require a new SIG)
+#### Project Leads(s)
+<NAMES>
+
+#### TC Sponsor
+<NAME>
+
+#### Delegated TC Sponsor (Optional)
+<NAME>
+
+#### GC Liaison
+<NAME>
+
+#### Other staffing
+<NAMES>
 
 ## Timeline
 
@@ -45,7 +62,7 @@ Issues should be properly labeled to indicate what parts of the specification it
 
 ## GitHub Project
 
-Once approved, a project should be managed using a GitHub project board (see [open projects](https://github.com/open-telemetry/community/projects?query=is%3Aopen)). This project board should be pre-populated with issues that cover all known deliverables, organized by timeline milestones.
+Once approved, a project should be managed using a GitHub project (see [open projects](https://github.com/open-telemetry/community/projects?query=is%3Aopen)). This project should be pre-populated with issues that cover all known deliverables, organized by timeline milestones.
 
 Any [member](./guides/contributor/membership.md) associated with the project can create the board. Please use the existing [GitHub Project template](https://github.com/orgs/open-telemetry/projects/140) to create your project, replacing `{project_name}` where appropriate.
 
@@ -59,7 +76,7 @@ See [project management](project-management.md#project-lifecycle) for more infor
 
 Once created, please add a link to the project board here.
 
-## SIG Meetings and Other Info
+## SIG Meetings and Other Info (New SIGs Only)
 
 Once a project is started, its corresponding SIG should meet regularly for discussion. These meeting times should be posted on the [OpenTelemetry public calendar](https://github.com/open-telemetry/community#calendar) and automatically recorded.
 


### PR DESCRIPTION
This change adapts wording in the project management doc, and the project template, to streamline the creation of projects as a way to communicate roadmap items for existing SIGs, inheriting sponsorship and staffing requirements from the existing SIG. It also aligns with recent changes to TC sponsorship requirements and clarifies the relationship between SIGs and projects.