### PR TITLE
Add repositories to sigs.yml

### DIFF
--- a/sigs.yml
+++ b/sigs.yml
@@ -371,6 +371,9 @@
       - https://github.com/open-telemetry/opentelemetry-collector
       - https://github.com/open-telemetry/opentelemetry-collector-contrib
       - https://github.com/open-telemetry/opentelemetry-collector-releases
+      - https://github.com/open-telemetry/opentelemetry-go-build-tools
+      - https://github.com/open-telemetry/opentelemetry-go-vanityurls
+      - https://github.com/open-telemetry/govanityurls
   - name: 'C++: SDK'
     meeting: Alternating between Monday at 13:00 PT and Wednesday at 09:00 PT
     notes:


### PR DESCRIPTION
This was requested as part of the CNCF graduation work.

A couple of repos don't have a SIG

- https://github.com/open-telemetry/opentelemetry-injector - SIG being added in #2875

- https://github.com/open-telemetry/opentelemetry-helm-charts - @open-telemetry/helm-maintainers I think we should add you to https://github.com/open-telemetry/community#implementation-sigs?

and these repos which probably make sense not to have a SIG:

- https://github.com/open-telemetry/community
- https://github.com/open-telemetry/.github
- https://github.com/open-telemetry/admin