### PR TITLE
Add roadmap management docs and adapt project management guidance

### DIFF
--- a/project-management.md
+++ b/project-management.md
@@ -56,7 +56,8 @@ Projects require the following resources to be successful:
 * Project leads and contributors willing to work on the project, see [Project Staffing](#project-staffing).
 * Sponsorship from OpenTelemetry leadership, see [Project Sponsorship](#project-sponsorship).
 
-To propose a project, a **project document** must be created using the [project proposal template](project-template.md) as a guide. This document will be used as the initial proposal for the project. . With the exception of sections labeled as "Optional" or "Post-Approval", all sections of the template must be filled out.
+To propose a project, a **project document** must be created using the [project proposal template](project-template.md) as a guide. This document will be used as the initial proposal for the project.
+With the exception of sections labeled as "Optional" or "Post-Approval", all sections of the template must be filled out.
 
 A project proposal can then be submitted by placing the project document in the [projects](projects/) folder and making a pull request against the `community` repo.
 

--- a/project-management.md
+++ b/project-management.md
@@ -34,8 +34,7 @@ In this case, projects help coordinate resources across SIGs, e.g. reviewing pro
 As documented under [Project Lifecycle](#project-lifecycle), all projects require a [GitHub project](https://docs.github.com/en/issues/planning-and-tracking-with-projects/learning-about-projects/about-projects) (i.e. a board), and for this to be kept up to date to communicate the status towards milestones and deliverables.
 
 Existing SIGs may also to use GitHub projects freely and independently, to track their ongoing work or communicate status of individual milestones.
-This is considered a good practice to provide a clear view of work in progress to the community
-However, it is not a requirement.
+This is considered a good practice to provide a clear view of work in progress to the community.
 
 The use of GitHub projects for this purpose does not require the creation of project proposals or approval from GC or TC.
 

--- a/project-management.md
+++ b/project-management.md
@@ -1,49 +1,106 @@
 # Project Management
 
 The OpenTelemetry community has limited bandwidth for managing changes which expand the scope of OpenTelemetry, or impact many SIGs (Special Interest Groups) within OpenTelemetry.
+In addition to gaining wider support from the community, projects help increase awareness across the industry, encouraging participation and improving collaboration.
 
 These are common scenarios which have this kind of impact:
 
 * Non-trivial changes to the [OpenTelemetry Specification](https://github.com/open-telemetry/opentelemetry-specification).
 * Non-trivial changes to the [OpenTelemetry Semantic Conventions](https://github.com/open-telemetry/semantic-conventions).
-  * Non-trivial being: introducing new conventions, forming a new SIG around a subject, topic or technology and stabilization efforts.
-* A new SIG being formed.
+  * Non-trivial being: introducing new conventions, forming a new SIG around a subject, topic or technology, and stabilization efforts.
+* A new SIG being formed, focusing on an initial set of deliverables before stabilizing.
 * An existing SIG taking on new work which will affect the OpenTelemetry project as a whole, and will need review from the broader community.
 
 Any changes which fall into one of the above categories must first create a project proposal and gain approval from the GC (Governance Committee) and TC (Technical Committee) before work begins.
 
-The list of current projects, along with their most recent status, is available in our [community projects](https://github.com/open-telemetry/community/projects?query=is%3Aopen) page, which the community can use to get a high-level view of the OpenTelemetry roadmap. Project proposals currently under review can be tracked via their respective [open pull requests](https://github.com/open-telemetry/community/pulls?q=is%3Aopen+is%3Apr+label%3Aarea%2Fproject-proposal).
+The list of current projects is available in the [projects](./projects) directory.
+Their most recent status, along with other roadmap items is available on the [OpenTelemetry Roadmap](https://github.com/orgs/open-telemetry/projects/155).
+
+Project proposals currently under review can be tracked via their respective [open pull requests](https://github.com/open-telemetry/community/pulls?q=is%3Aopen+is%3Apr+label%3Aarea%2Fproject-proposal).
+
+## Relation to SIGs, GitHub Projects, and Roadmap
+### SIGs
+
+A project is generally required to form a new SIG.
+When a project is created to form a new SIG, it should focus on an initial set of deliverables.
+After these are completed, the SIG may decide to transition to permanent operation, or dissolve if no more work is required in that area.
+
+A new SIG is not required for every project.
+Some projects that require coordination across multiple areas of OpenTelemetry may be led by existing SIGs.
+In this case, projects help coordinate resources across SIGs, e.g. reviewing prototypes.
+
+### GitHub Projects (i.e. Boards)
+
+As documented under [Project Lifecycle](#project-lifecycle), all projects require a [GitHub project](https://docs.github.com/en/issues/planning-and-tracking-with-projects/learning-about-projects/about-projects) (i.e. a board), and for this to be kept up to date to communicate the status towards milestones and deliverables.
+
+Existing SIGs may also to use GitHub projects freely and independently, to track their ongoing work or communicate status of individual milestones.
+This is considered a good practice to provide a clear view of work in progress to the community
+However, it is not a requirement.
+
+The use of GitHub projects for this purpose does not require the creation of project proposals or approval from GC or TC.
+
+### OpenTelemetry Roadmap
+
+The [OpenTelemetry Roadmap](https://github.com/orgs/open-telemetry/projects/155) contains a high-level view of all major deliverables across the whole project.
+This roadmap view is built from the information and status contained in specific GitHub projects across OpenTelemetry.
+
+All approved proposals under the [projects](./projects) directory are implicitly part of the OpenTelemetry Roadmap, along with other SIG-specific projects explicitly added to said roadmap.
+
+For more info see [Roadmap Management](./roadmap-management.md).
 
 ## Project Proposal
 
-At minimum, projects require the following resources to be successful:
+Projects require the following resources to be successful:
 
-* A clearly defined set of goals and deliverables.
-* Timelines for when the deliverables will be ready for review by the broader community.
-* Two TC/GC members, or community members delegated by them, to sponsor the project.
-  These two sponsors should be from different companies.
-* A group of designers and subject matter experts, dedicating a significant amount of their work time to the project. These participants are needed to design the spec, write a set of OTEPs, and create multiple prototypes. This group needs to meet with each other (and with their sponsors) on a regular basis to develop a successful set of proposals.
+* A clearly defined set of problems to solve, goals, and deliverables.
+* Expected timelines for when the deliverables will be ready for review by the broader community.
+* Project leads and contributors willing to work on the project, see [Project Staffing](#project-staffing).
+* Sponsorship from OpenTelemetry leadership, see [Project Sponsorship](#project-sponsorship).
 
-To propose a project, a **project document** must be created using the [project proposal template](project-template.md) as a guide. This document will be used as the initial proposal for the project. With the exception of sections labeled as "Optional" or "Post-Approval", all sections of the template must be filled out.
+To propose a project, a **project document** must be created using the [project proposal template](project-template.md) as a guide. This document will be used as the initial proposal for the project. . With the exception of sections labeled as "Optional" or "Post-Approval", all sections of the template must be filled out.
 
-A project proposal can then be submitted by placing the project document in the [projects](projects/) folder and making a pull request against the community repo.
+A project proposal can then be submitted by placing the project document in the [projects](projects/) folder and making a pull request against the `community` repo.
 
 As the project progresses, the project document should be kept up to date, and the community [README](README.md) should be updated to include any new project meeting information (see [contributing guide](https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md#updating-sig-information-on-the-readmemd)).
 
 The project template may be updated and new or existing sections may become required for new projects. Existing projects are not required to update their project documents to the latest template.
 
-Project leads are encouraged to define timelines for any work which will require public review, and to provide updates to the community in the form of [GitHub Project updates](https://docs.github.com/en/issues/planning-and-tracking-with-projects/learning-about-projects/sharing-project-updates). We have found that having scoped deliverables leads to an increased cadence in project work, and helps resolve debate. Timelines also help with getting a more coherent public review, as they allow the review community to plan on making themselves available. If timelines prove to be unrealistic, they can be always be updated.
+Project leads are encouraged to define timelines for any work which will require public review, and to provide updates to the community in the form of [GitHub project updates](https://docs.github.com/en/issues/planning-and-tracking-with-projects/learning-about-projects/sharing-project-updates). We have found that having scoped deliverables leads to an increased cadence in project work, and helps resolve debate. Timelines also help with getting a more coherent public review, as they allow the review community to plan on making themselves available. If timelines prove to be unrealistic, they can be always be updated.
+
+## Project Staffing
+
+The following staffing requirements must be met for any project proposal.
+
+* Project lead(s), who are willing to bottom line the project and address any issues which are not handled by other project members.
+  * If the project requires the creation of a new SIG, these will become SIG maintainers, or approvers for a new Semantic Conventions SIG.
+* A set of contributors willing to work on the deliverables outlined in the project proposal.
+* If appropriate to ensure success for project (e.g. large spec changes):
+  * Engineers willing to write prototypes in at least two languages. Languages should be fairly different from each other, for example Java and Python.
+  * Maintainers or approvers from other SIGs committed to reviewing the prototypes.
+
+## Project Sponsorship
+
+All projects require sponsorship, ensuring those leading and working on the project are supported and set up for success.
+
+If a project is led by an existing SIG, TC sponsor and GC liaison for that SIG are assumed to be the sponsor and liaison for the project.
+
+If a project involves the creation of a new SIG, it cannot be started until the following have been agreed:
+
+* A [TC](community-members.md#technical-committee) sponsor according to [TC sponsorship requirements](tech-committee-charter.md#sponsorship-requirements).
+  * In the case of semantic convention SIGs, [semantic convention maintainers](https://github.com/orgs/open-telemetry/teams/specs-semconv-maintainers) or community members delegated by them can act as sponsors, supported by a _TC Escalation Sponsor_.
+* A [GC](community-members.md#governance-committee) liaison to facilitate this SIG's health and ensure project scope remains true to the project description (see [GC check-ins](./gc-check-ins.md)).
 
 ## Project Lifecycle
 
-All projects progress through a lifecycle. Each individual project is tracked using a specific [GitHub Project](https://docs.github.com/en/issues/planning-and-tracking-with-projects/learning-about-projects/about-projects) created for this purpose after the proposal is approved. Project leads should use it to plan work and communicate status updates to the community.
+All projects progress through a lifecycle. Each individual project is tracked using a specific [GitHub project](https://docs.github.com/en/issues/planning-and-tracking-with-projects/learning-about-projects/about-projects) created for this purpose after the proposal is approved.
+Project leads should use it to plan work and communicate status updates to the community. These will be automatically rolled up to the wider OpenTelemetry Roadmap (see [Roadmap Management](./roadmap-management.md) for more info).
 
 The project lifecycle is as follows:
 
 * A **Project Proposal** pull request is created, as described above. The pull request should be labeled as `area/project-proposal`, which opens it up for community review.
   * For a project to be approved, its pull request **must be approved by a majority of GC members**. If a project is approved, and all merge requirements are met, the pull request is merged.
-* One a project is **Approved**, project leads create the corresponding GitHub Project and set up meetings and other logistics as documented in the project proposal template.
-* For the duration of the project, project leads, along with their GC liaisons, are expected to regularly (at minimum quarterly) [share project updates](https://docs.github.com/en/issues/planning-and-tracking-with-projects/learning-about-projects/sharing-project-updates) to communicate the status of the project to the wider community. The list of possible statuses any given project is static, and it represents the following in OpenTelemetry projects:
+* One a project is **Approved**, project leads create the corresponding GitHub project and set up meetings and other logistics as documented in the project proposal template.
+* For the duration of the project, project leads, along with their GC liaisons, are expected to regularly (at minimum quarterly) [share project updates](https://docs.github.com/en/issues/planning-and-tracking-with-projects/learning-about-projects/sharing-project-updates) to communicate the status of the project to the wider community. The list of possible statuses any given project is static, and it represents the following:
   * **_Inactive_**: The project has been approved, but its start date is in the future and no work has commenced. Although allocating a future start date is not required, it lets potential contributors know when they need to make themselves available, and get prepared to begin their work. Subject matter experts and participants who plan to do a lot of work – such as building prototypes – benefit greatly from having a start date, as they can plan for their participation with their employers and coworkers. Projects may remain in _inactive_ state until defined start date is reached.
   * **_On Track_**: The project is making progress, and leads consider the timelines currently defined in the project document achievable with the current resources. Updates may contain information about recent achievements on the project.
   * **_At Risk_**: The project is at risk of not meeting its currently defined timelines. Leads and their GC liaison should discuss actions to bring the project back on track, which may include extending previously agreed timelines or re-scoping deliverables.

--- a/project-management.md
+++ b/project-management.md
@@ -82,7 +82,9 @@ The following staffing requirements must be met for any project proposal.
 
 All projects require sponsorship, ensuring those leading and working on the project are supported and set up for success.
 
-If a project is led by an existing SIG, TC sponsor and GC liaison for that SIG are assumed to be the sponsor and liaison for the project.
+If a project proposal is led by an existing SIG, TC sponsor and GC liaison for that SIG are assumed to be the sponsor and liaison for the new project.
+However, before approving the project, TC sponsorship level must be reviewed by the current TC sponsor.
+This ensures that the existing SIG is sufficiently supported if its scope is extended.
 
 If a project involves the creation of a new SIG, it cannot be started until the following have been agreed:
 

--- a/project-management.md
+++ b/project-management.md
@@ -14,7 +14,7 @@ These are common scenarios which have this kind of impact:
 Any changes which fall into one of the above categories must first create a project proposal and gain approval from the GC (Governance Committee) and TC (Technical Committee) before work begins.
 
 The list of current projects is available in the [projects](./projects) directory.
-Their most recent status, along with other roadmap items is available on the [OpenTelemetry Roadmap](https://github.com/orgs/open-telemetry/projects/155).
+Their most recent status, along with other roadmap items is available on the [OpenTelemetry Roadmap](https://github.com/orgs/open-telemetry/projects/158).
 
 Project proposals currently under review can be tracked via their respective [open pull requests](https://github.com/open-telemetry/community/pulls?q=is%3Aopen+is%3Apr+label%3Aarea%2Fproject-proposal).
 
@@ -40,7 +40,7 @@ The use of GitHub projects for this purpose does not require the creation of pro
 
 ### OpenTelemetry Roadmap
 
-The [OpenTelemetry Roadmap](https://github.com/orgs/open-telemetry/projects/155) contains a high-level view of all major deliverables across the whole project.
+The [OpenTelemetry Roadmap](https://github.com/orgs/open-telemetry/projects/158) contains a high-level view of all major deliverables across the whole project.
 This roadmap view is built from the information and status contained in specific GitHub projects across OpenTelemetry.
 
 All approved proposals under the [projects](./projects) directory are implicitly part of the OpenTelemetry Roadmap, along with other SIG-specific projects explicitly added to said roadmap.

--- a/project-template.md
+++ b/project-template.md
@@ -1,6 +1,8 @@
 # <<PROJECT NAME>>
 
-Name your project here. This should be a short, descriptive name that describes the main goal of the project, not the SIG that may be formed as part of it. For instance, if the project is aimed at the first set of deliverables for the Foo SIG, name the project "Foo SIG Bootstrap" or "Initial Foo Implementation".
+Name your project here. This should be a short, descriptive name that describes the main goal of the project, or the main deliverable, not the SIG that may be formed as part of it.
+
+For instance, if the project is aimed at the first set of deliverables for the Foo SIG, name the project "Foo SIG Bootstrap" or "Initial Foo Implementation", not "Foo SIG".
 
 ## Background and description
 
@@ -20,24 +22,41 @@ In general, OTEPs are not accepted unless they come with working prototypes avai
 
 ## Staffing / Help Wanted
 
-Who is currently planning to work on the project? If a project requires specialized domain expertise, please list it here. If a project is missing a critical mass of people in order to begin work, please clarify.
-
 ### Industry outreach (Optional)
 
 Who (people, companies) in the industry should be aware of this effort? Was there an attempt to get them onboard? What did they say?
 
+### SIG
+Name of the SIG that will lead this work.
+If this project requires the creation of a new SIG, specify the name here.
+
 ### Required staffing
+See [Project Staffing](/project-management.md#project-staffing)
 
-Projects cannot be started until the following participants have been identified:
-* Every project needs a project lead, who is willing to bottom line the project and address any issues which are not handled by other project members.
-* At least two sponsoring [TC](community-members.md#technical-committee) or [GC](community-members.md#governance-committee) members (or [semantic convention maintainers](https://github.com/orgs/open-telemetry/teams/specs-semconv-maintainers) in the case of semantic convention SIGs), or community members delegated by them. Sponsors are dedicated to attending meetings, reviewing proposals, and in general being aware of the state of the project and its technical details. Sponsors guide the project through the spec process, keep the tracking issue up to date, and help to ensure that relevant community members provide input at the appropriate times.
-* A GC liaison to facilitate this SIG's health and ensure project scope remains true to the project description. If a GC member is also a sponsor for this project, they are by default the GC liaison (see [GC check-ins](./gc-check-ins.md)).
-* Engineers willing to write prototypes in at least two languages (if relevant to project). Languages should be fairly different from each other (for example: Java and Python).
-* Maintainers or approvers from those languages committed to reviewing the prototypes.
+#### Project Leads(s)
+Name(s) of project lead(s)
 
-## Timeline
+#### Other Staffing
+Names and expected contribution of any other contributors
 
-What is the expected timeline the project will aim to adhere to, and what resources and deliverables will be needed for each portion of the timeline? If the project has not been started, please describe this timeline in relative terms (one month in, two weeks later, etc). If a project has started, please include actual dates.
+### Sponsorship
+See [Project Sponsorship](/project-management.md#project-sponsorship)
+
+#### TC Sponsor
+Name of TC sponsor
+
+#### Delegated TC Sponsor (Optional)
+Name of delegated TC sponsor
+
+#### GC Liaison
+Name of GC liaison
+
+## Expected Timeline
+
+What is the expected timeline the project will aim to adhere to, and what resources and deliverables will be needed for each portion of the timeline?
+Please describe this timeline in relative terms here (one month in, two weeks later, etc).
+
+After the project has started, please use GitHub project updates to set specific target start and completion dates (see [Project Lifecycle](project-management.md#project-lifecycle) for more information).
 
 ## Labels (Optional)
 
@@ -45,24 +64,26 @@ Issues should be properly labeled to indicate what parts of the specification it
 
 ## GitHub Project (Post-Approval)
 
-Once approved, a project should be managed using a GitHub project board (see [open projects](https://github.com/open-telemetry/community/projects?query=is%3Aopen)). This project board should be pre-populated with issues that cover all known deliverables, organized by timeline milestones.
+Once approved, a project should be managed using a [GitHub project](https://docs.github.com/en/issues/planning-and-tracking-with-projects/learning-about-projects/about-projects). This project should be pre-populated with issues that cover all known deliverables, organized by timeline milestones.
 
-Any [member](./guides/contributor/membership.md) associated with the project can create the board. Please use the existing [GitHub Project template](https://github.com/orgs/open-telemetry/projects/140) to create your project, replacing `{project_name}` where appropriate.
+Any [member](./guides/contributor/membership.md) associated with the project can create the board.
+Please use the existing [GitHub Project template](https://github.com/orgs/open-telemetry/projects/140) to create your project, replacing placeholders as appropriate.
 
 Once created, the creator of the board should:
 
 - Assign `Admin` privileges on the project to the relevant project members (using a new or existing GitHub team).
-- Change the visibility of the project to `Public` in order to share project status and priorities outside of the OpenTelemetry organization.
+- Change the visibility of the project to `Public` in order to share project status and priorities outside the OpenTelemetry organization (default in template).
 - Configure project workflows to automatically add issues and PRs to the board based on repositories and labels.
 
-See [project management](project-management.md#project-lifecycle) for more information about sharing project updates and status.
+See [Project Lifecycle](project-management.md#project-lifecycle) for more information about sharing project updates and status.
 
 Once created, please add a link to the project board here.
 
-## SIG Meetings and Other Info (Post-Approval)
+## SIG Meetings, Roadmap, and Other Info (Post-Approval)
 
 Once a project is started, its corresponding SIG should meet regularly for discussion. These meeting times should be posted on the [OpenTelemetry public calendar](https://github.com/open-telemetry/community#calendar) and automatically recorded.
 
 Any relevant information related to the SIG (e.g. sponsors, meeting times, Slack channels, meeting notes, etc.) must be publicly available in the [community](https://github.com/open-telemetry/community) SIG tables, which can be updated via the [sigs.yml](./sigs.yml) file and running `make table-generation`.
+Please ensure that GitHub project ID is added to `roadmap_project_ids` to include this project in the OpenTelemetry Roadmap (see [Roadmap Management](./roadmap-management.md) for more information).
 
 See [How to create and configure meetings](./docs/how-to-handle-public-calendar.md) for updating the public calendar or open an issue in the community repository so it's taken care of.

--- a/project-template.md
+++ b/project-template.md
@@ -37,7 +37,8 @@ See [Project Staffing](/project-management.md#project-staffing)
 Name(s) of project lead(s)
 
 #### Other Staffing
-Names and expected contribution of any other contributors
+Names and expected contribution of any other contributors.
+Please also include maintainers or approvers from other SIGs committed to reviewing prototypes.
 
 ### Sponsorship
 See [Project Sponsorship](/project-management.md#project-sponsorship)

--- a/roadmap-management.md
+++ b/roadmap-management.md
@@ -8,7 +8,6 @@ This consolidated view, managed by the GC (Governance Committee) and TC (Technic
 Publicly available at **[OpenTelemetry Roadmap](https://github.com/orgs/open-telemetry/projects/155)**, this view is currently backed by issues in the [open-telemetry/.roadmap](https://github.com/open-telemetry/.roadmap) repository.
 These issues are populated automatically from a selected subset of GitHub [projects](https://github.com/orgs/open-telemetry/projects?query=is%3Aopen) in order to overcome [limitations](https://github.com/orgs/community/discussions/157993) in GitHub's native [project](https://docs.github.com/en/issues/planning-and-tracking-with-projects/learning-about-projects/about-projects) functionality.
 
-
 Some of these projects correspond to initiatives entirely driven within the scope of specific SIGs (Special Interest Groups), and some correspond to cross-cutting initiatives that require SIGs –existing or needing creation– to follow the [Project Management](./project-management.md) process.
 
 Individual OpenTelemetry projects are managed by their leads independently, with the support from their TC sponsor and GC liaison, as documented in their respective charters.
@@ -23,13 +22,15 @@ Specifically, the following project details are synced into their corresponding 
   * **Start Date**: The projected start of the work.
   * **Target Date**: The expected completion date.
 
+Other information, like the SIG leading a project, is collected from [sigs.yml](./sigs.yml).
+
 Project leads may use any other GitHub project features like short descriptions, milestones, etc. to manage individual projects. 
 
 This mechanism allows for a centralized roadmap view while letting individual project teams manage their work and status independently in their own projects.
 
 ## Roadmap Item Selection
 
-For a project to appear on the official roadmap, its ID must be added to [sigs.yml](./sigs.yml) in the list of `roadmap_project_ids` under its corresponding SIG.
+For a project to appear on the official roadmap, its ID must be added to [sigs.yml](./sigs.yml) in the list of `roadmapProjectIDs` under its corresponding SIG.
 This is an opt-in process, coordinated by GC and TC.
 
 Current and potential roadmap items are evaluated by TC and GC, in collaboration with all SIGs, on an ongoing basis, and collectively reviewed at the annual OpenTelemetry Leadership Meeting.

--- a/roadmap-management.md
+++ b/roadmap-management.md
@@ -1,0 +1,35 @@
+# OpenTelemetry Roadmap Management
+
+The **[OpenTelemetry Roadmap](https://github.com/orgs/open-telemetry/projects/155)** provides a high-level, cross-cutting view of major initiatives, their status, and target completion dates across the entire project.
+This consolidated view, managed by the GC (Governance Committee) and TC (Technical Committee), helps community members and adopters understand the project's direction and when to expect key deliverables.
+
+## Consolidated Roadmap View
+
+Publicly available at **[OpenTelemetry Roadmap](https://github.com/orgs/open-telemetry/projects/155)**, this view is currently backed by issues in the [open-telemetry/.roadmap](https://github.com/open-telemetry/.roadmap) repository.
+These issues are populated automatically from a selected subset of GitHub [projects](https://github.com/orgs/open-telemetry/projects?query=is%3Aopen) in order to overcome [limitations](https://github.com/orgs/community/discussions/157993) in GitHub's native [project](https://docs.github.com/en/issues/planning-and-tracking-with-projects/learning-about-projects/about-projects) functionality.
+
+
+Some of these projects correspond to initiatives entirely driven within the scope of specific SIGs (Special Interest Groups), and some correspond to cross-cutting initiatives that require SIGs –existing or needing creation– to follow the [Project Management](./project-management.md) process.
+
+Individual OpenTelemetry projects are managed by their leads independently, with the support from their TC sponsor and GC liaison, as documented in their respective charters.
+Jointly, they are responsible for keeping the project details up-to-date.
+
+Specifically, the following project details are synced into their corresponding `.roadmap` issues, for presentation purposes:
+
+* **Project Name**: The name of the project, representing the overall initiative.
+* **README**: A summary of the project's goals and deliverables.
+* **Status Update**: The latest reported [project update](https://docs.github.com/en/issues/planning-and-tracking-with-projects/learning-about-projects/sharing-project-updates). In particular:
+  * **Status**: e.g., _On Track_, _At Risk_, _Completed_, etc.
+  * **Start Date**: The projected start of the work.
+  * **Target Date**: The expected completion date.
+
+Project leads may use any other GitHub project features like short descriptions, milestones, etc. to manage individual projects. 
+
+This mechanism allows for a centralized roadmap view while letting individual project teams manage their work and status independently in their own projects.
+
+## Roadmap Item Selection
+
+For a project to appear on the official roadmap, its ID must be added to [sigs.yml](./sigs.yml) in the list of `roadmap_project_ids` under its corresponding SIG.
+This is an opt-in process, coordinated by GC and TC.
+
+Current and potential roadmap items are evaluated by TC and GC, in collaboration with all SIGs, on an ongoing basis, and collectively reviewed at the annual OpenTelemetry Leadership Meeting.

--- a/roadmap-management.md
+++ b/roadmap-management.md
@@ -1,11 +1,11 @@
 # OpenTelemetry Roadmap Management
 
-The **[OpenTelemetry Roadmap](https://github.com/orgs/open-telemetry/projects/155)** provides a high-level, cross-cutting view of major initiatives, their status, and target completion dates across the entire project.
+The **[OpenTelemetry Roadmap](https://github.com/orgs/open-telemetry/projects/158)** provides a high-level, cross-cutting view of major initiatives, their status, and target completion dates across the entire project.
 This consolidated view, managed by the GC (Governance Committee) and TC (Technical Committee), helps community members and adopters understand the project's direction and when to expect key deliverables.
 
 ## Consolidated Roadmap View
 
-Publicly available at **[OpenTelemetry Roadmap](https://github.com/orgs/open-telemetry/projects/155)**, this view is currently backed by issues in the [open-telemetry/.roadmap](https://github.com/open-telemetry/.roadmap) repository.
+Publicly available at **[OpenTelemetry Roadmap](https://github.com/orgs/open-telemetry/projects/158)**, this view is currently backed by issues in the [open-telemetry/.roadmap](https://github.com/open-telemetry/.roadmap) repository.
 These issues are populated automatically from a selected subset of GitHub [projects](https://github.com/orgs/open-telemetry/projects?query=is%3Aopen) in order to overcome [limitations](https://github.com/orgs/community/discussions/157993) in GitHub's native [project](https://docs.github.com/en/issues/planning-and-tracking-with-projects/learning-about-projects/about-projects) functionality.
 
 Some of these projects correspond to initiatives entirely driven within the scope of specific SIGs (Special Interest Groups), and some correspond to cross-cutting initiatives that require SIGs –existing or needing creation– to follow the [Project Management](./project-management.md) process.

--- a/sigs.yml
+++ b/sigs.yml
@@ -54,8 +54,6 @@
       github: danielgblanco
     repositories:
       - https://github.com/open-telemetry/opentelemetry-configuration
-    roadmapProjectIDs:
-      - 55
   - name: 'Specification: Logs'
     meeting: Tuesday at 10:00 PT
     notes:
@@ -112,6 +110,8 @@
     gcLiaison:
       - name: 'Pablo Baeyens'
         github: mx-psi
+    roadmapProjectIDs:
+      - 55
   - name: 'Semantic Conventions: K8s'
     meeting: Every other Wednesday at 08:00 PT
     notes:

--- a/sigs.yml
+++ b/sigs.yml
@@ -32,6 +32,8 @@
     gcLiaison:
     - name: 'Juraci Paixão Kröhling'
       github: jpkrohling
+    roadmapProjectIDs:
+      - 133
   - name: 'Specification: Configuration'
     meeting: Every other Monday at 08:00 PT
     notes:
@@ -52,6 +54,8 @@
       github: danielgblanco
     repositories:
       - https://github.com/open-telemetry/opentelemetry-configuration
+    roadmapProjectIDs:
+      - 55
   - name: 'Specification: Logs'
     meeting: Tuesday at 10:00 PT
     notes:
@@ -126,6 +130,8 @@
     gcLiaison:
       - name: Alolita Sharma
         github: alolita
+    roadmapProjectIDs:
+      - 114
   - name: 'Semantic Conventions and Instrumentation: GenAI'
     meeting: Every Tuesday 9:00 PT and every other Tuesday 10:00 UTC+8
     notes:
@@ -144,6 +150,8 @@
     gcLiaison:
     - name: Ted Young
       github: tedsuo
+    roadmapProjectIDs:
+      - 82
   - name: 'Semantic Conventions: CI/CD'
     meeting: Every Thursday at 06:00 PT
     notes:
@@ -162,6 +170,8 @@
     gcLiaison:
       - name: Daniel Gomez Blanco
         github: danielgblanco
+    roadmapProjectIDs:
+      - 79
   - name: 'Semantic Conventions: Security'
     meeting: "Meets during Semantic Conventions: General"
     notes:
@@ -178,6 +188,8 @@
     gcLiaison:
       - name: Trask Stalnaker
         github: trask
+    roadmapProjectIDs:
+      - 104
   - name: 'Specification: Entities'
     meeting: Every other Thursday at 08:00 PT
     notes:
@@ -196,6 +208,8 @@
     gcLiaison:
       - name: 'Severin Neumann'
         github: svrnm
+    roadmapProjectIDs:
+      - 85
   - name: OpAMP
     meeting: Every other Wednesday at 11:00 PT
     notes:
@@ -299,6 +313,8 @@
     gcLiaison:
     - name: Daniel Gomez Blanco
       github: danielgblanco
+    roadmapProjectIDs:
+      - 19
 - name: Implementation SIGs
   sigs:
   - name: 'Android: SDK + Automatic Instrumentation'
@@ -331,6 +347,8 @@
     gcLiaison:
       - name: 'Trask Stalnaker'
         github: trask
+    roadmapProjectIDs:
+      - 139
     repositories:
       - https://github.com/open-telemetry/otel-arrow
   - name: Browser
@@ -353,6 +371,8 @@
     gcLiaison:
       - name: 'Daniel Gomez Blanco'
         github: danielgblanco
+    roadmapProjectIDs:
+      - 146
   - name: Collector
     meeting: Alternating between Tuesday at 17:00 PT, Wednesday at 09:00 PT, and Wednesday at 05:00 PT
     notes:
@@ -495,6 +515,8 @@
       github: jpkrohling
     repositories:
       - https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation
+    roadmapProjectIDs:
+      - 130
   - name: 'Injector'
     meeting: Monday at 09:30 PT
     notes:
@@ -760,6 +782,8 @@
       github: svrnm
     repositories:
       - https://github.com/open-telemetry/opentelemetry.io
+    roadmapProjectIDs:
+      - 129
   - name: End-User SIG
     meeting: Every other Thursday at 10:00 PT
     notes:

--- a/sigs.yml
+++ b/sigs.yml
@@ -54,6 +54,8 @@
       github: danielgblanco
     repositories:
       - https://github.com/open-telemetry/opentelemetry-configuration
+    roadmapProjectIDs:
+        - 38
   - name: 'Specification: Logs'
     meeting: Tuesday at 10:00 PT
     notes:

--- a/sigs.yml
+++ b/sigs.yml
@@ -396,6 +396,8 @@
       - https://github.com/open-telemetry/opentelemetry-go-build-tools
       - https://github.com/open-telemetry/opentelemetry-go-vanityurls
       - https://github.com/open-telemetry/govanityurls
+    roadmapProjectIDs:
+      - 83
   - name: 'C++: SDK'
     meeting: Alternating between Monday at 13:00 PT and Wednesday at 09:00 PT
     notes:


### PR DESCRIPTION
* Adds clarifications on how community projects relate to SIGs, GitHub projects, and wider OpenTelemetry roadmap.
* Removes text in the project template to link to project management documentation instead.
* Clarifies required project staffing and sponsorship, especially for existing SIGs.
* Adapts project lifecycle and communication mechanisms to align with OpenTelemetry roadmap.
* Adds documentation about OpenTelemetry roadmap management.
* Adds current community projects to `sigs.yml` (this will be missing some roadmap items, which can be added before PR is merged)

I will leave this PR as draft until the changes to `sigs.yml`, along with the scripts/actions to handle syncing between projects and issues in `.roadmap` (still named `.project` at the time of writing) are merged. These will be added in a separate PR so that when this is merge the OpenTelemetry is already in place.