### PR TITLE
add details about human responsibility to genai policy

### DIFF
--- a/guides/README.md
+++ b/guides/README.md
@@ -16,8 +16,8 @@ everyone is welcome to contribute to them!
 
 ## Policies and Community Standards
 
-In addition to these guides, familiarize yourself with our community policies and standards:
+In addition to these guides, familiarize yourself with our community policies:
 
-- [Code of Conduct](../code-of-conduct.md) - Our community standards and expectations
-- [Generative AI Policy](../policies/genai.md) - Guidelines for using AI tools in contributions
-- [Third-party Meeting Recordings Policy](../policies/third-party-meeting-recordings.md) - Rules for recording and transcribing meetings
+- [Code of Conduct](../code-of-conduct.md)
+- [Generative AI Policy](../policies/genai.md)
+- [Third-party Meeting Recordings Policy](../policies/third-party-meeting-recordings.md)

--- a/guides/README.md
+++ b/guides/README.md
@@ -7,10 +7,17 @@ the OpenTelemetry community. These should be considered a living resource, and
 everyone is welcome to contribute to them!
 
 - [Contributor Guide](./contributor/README.md)
-  - [Policy on Generative AI Contributions](./contributor/genai.md)
   - [Donations of Pre-Existing Code](./contributor/donations.md)
   - [Becoming a Member of the OpenTelemetry Project](./contributor/membership.md)
   - [The Contribution Lifecycle](./contributor/processes.md)
 - [Maintainer Guide](./maintainer/README.md)
   - [Resolving Technical Conflicts](./maintainer/conflict-resolution.md)
   - [Managing Popular GitHub Issues](./maintainer/popular-issues.md)
+
+## Policies and Community Standards
+
+In addition to these guides, familiarize yourself with our community policies and standards:
+
+- [Code of Conduct](../code-of-conduct.md) - Our community standards and expectations
+- [Generative AI Policy](../policies/genai.md) - Guidelines for using AI tools in contributions
+- [Third-party Meeting Recordings Policy](../policies/third-party-meeting-recordings.md) - Rules for recording and transcribing meetings

--- a/policies/genai.md
+++ b/policies/genai.md
@@ -51,7 +51,14 @@ Examples of this include:
 
 ### Human Responsibility and Control
 
-The human driving any contribution—whether as an author, reviewer, or maintainer—must remain in control of the process and bear full responsibility for the final output. This means actively reviewing, understanding, and validating any LLM-generated content before submission. You cannot delegate your responsibility to an AI tool, nor can you claim that an AI made an error as a defense for problematic contributions. The human contributor is accountable for ensuring that all content, regardless of its origin, meets project standards, follows established policies, and contributes meaningfully to the OpenTelemetry ecosystem.
+The human driving any contribution—whether as an author, reviewer, or maintainer—must
+remain in control of the process and bear full responsibility for the final output.
+This means actively reviewing, understanding, and validating any LLM-generated content
+before submission. You cannot delegate your responsibility to an AI tool, nor can you
+claim that an AI made an error as a defense for problematic contributions. The human
+contributor is accountable for ensuring that all content, regardless of its origin,
+meets project standards, follows established policies, and contributes meaningfully
+to the OpenTelemetry project.
 
 ## Frequently Asked Questions - Contributors
 

--- a/policies/genai.md
+++ b/policies/genai.md
@@ -12,7 +12,13 @@ projects may -- at their discretion -- hide or close issues, pull requests, or
 other contributions that are made totally or in part through generative AI
 tooling.
 
+The human driving any contribution is responsible for ensuring that LLM-generated
+content aligns with project guidelines and policies, especially this generative
+document and the aforementioned Linux Foundation Generative AI Policy.
+
 ## The Long Version
+
+### General Guidelines for Generative AI Usage
 
 Increasingly, we have observed a trend of contributors who are utilizing LLMs
 and other generative tools to participate in issues and create pull requests.
@@ -38,10 +44,14 @@ output as the sole basis for their contributions.
 Examples of this include:
 
 - Copying and pasting LLM output into issues or pull requests without any
-additional context or explanation.
+  additional context or explanation.
 - Reviewing existing pull requests solely via
-LLMs, or using LLMs to respond to issues without any additional context or
-explanation.
+  LLMs, or using LLMs to respond to issues without any additional context or
+  explanation.
+
+### Human Responsibility and Control
+
+The human driving any contribution—whether as an author, reviewer, or maintainer—must remain in control of the process and bear full responsibility for the final output. This means actively reviewing, understanding, and validating any LLM-generated content before submission. You cannot delegate your responsibility to an AI tool, nor can you claim that an AI made an error as a defense for problematic contributions. The human contributor is accountable for ensuring that all content, regardless of its origin, meets project standards, follows established policies, and contributes meaningfully to the OpenTelemetry ecosystem.
 
 ## Frequently Asked Questions - Contributors
 


### PR DESCRIPTION
follow up to this comment I made a while back: https://github.com/open-telemetry/community/issues/2851#issuecomment-3077531890

> Can we maybe codify that in our policy somehow to say "the human driving the PR (author or not) is owning what the LLM generates, it's their responisbility to ensure that it is in line with all policies, especially the genai policies (otel & LF)." This way we provide some clarity around that and make the implicit intend explicit. Happy to provide the PR for that.

And, yes, I used a LLM to help me to write out those paragraphs;-) 