### PR TITLE
Discontinue client-side instrumentation project

### DIFF
--- a/projects/completed-projects/client-instrumentation.md
+++ b/projects/completed-projects/client-instrumentation.md
@@ -1,5 +1,11 @@
 # Client Instrumentation
 
+> [!IMPORTANT]
+> This project has been discontinued.
+> Browser-specific work has been moved to https://github.com/orgs/open-telemetry/projects/146.
+> 
+> SIG Client-Side is now focusing solely on cross-cutting aspects for both mobile and browser (e.g. sessions)
+
 ## Description
 
 We believe that in order for OpenTelemetry to be adopted across the board, it needs to have a good support for client applications. Client instrumentation has some unique challenges that are currently not well supported.

--- a/sigs.yml
+++ b/sigs.yml
@@ -333,8 +333,7 @@
     gcLiaison:
     - name: Daniel Gomez Blanco
       github: danielgblanco
-    roadmapProjectIDs:
-      - 19
+    roadmapProjectIDs: []
 - name: Implementation SIGs
   sigs:
   - name: 'Android: SDK + Automatic Instrumentation'


### PR DESCRIPTION
As documented, part of this project has now been superseded by https://github.com/orgs/open-telemetry/projects/146, and client-side SIG will focus solely on cross-cutting aspects for both mobile and browser.