### PR TITLE
Use opentelemetry group for election roll

### DIFF
--- a/scripts/gc-elections/generate-voters-roll.py
+++ b/scripts/gc-elections/generate-voters-roll.py
@@ -47,7 +47,7 @@ def get_users_and_contributions():
                     "uid": "P172949F98CB31475",
                     "type": "postgres"
                 },
-                "rawSql": "select sub.name as name, sub.value as contributions from (select split_part(name, '$$$', 1) as name, sum(value) as value from shdev where series = 'hdev_contributionsallall' and period = 'y' group by split_part(name, '$$$', 1) ) sub where sub.value >= 20 order by name",
+                "rawSql": "select sub.name as name, sub.value as contributions from (select split_part(name, '$$$', 1) as name, sum(value) as value from shdev where series = 'hdev_contributionsopentelemetryall' and period = 'y' group by split_part(name, '$$$', 1) ) sub where sub.value >= 20 order by name",
                 "format": "table"
             }
         ],


### PR DESCRIPTION
The current election voter roll script uses the `All` repository group when querying for voter eligibility (taken from [this view](https://opentelemetry.devstats.cncf.io/d/9/developer-activity-counts-by-repository-group-table?orgId=1&var-period_name=Last%20year&var-metric=contributions&var-repogroup_name=All&var-country_name=All)). This used to return all contributors, including those with less than 20 contributions.

The current behaviour seen is that this same filter now stops at a certain spot depending on the range of the query, and when using the `Last year` filter, it stops at 25.

The change in this PR changes the `All` repository group to `opentelemetry`, which still contains contributions to all repositories, to a lowest value of 13 (see [this view](https://opentelemetry.devstats.cncf.io/d/9/developer-activity-counts-by-repository-group-table?orgId=1&var-period_name=Last%20year&var-metric=contributions&var-repogroup_name=open-telemetry&var-country_name=All)).

While a better approach is needed for next year (especially considering how things are moving to LFX Insights) I believe this can solve this issue for this year's election.