### PR TITLE
Remove TC Chair position

### DIFF
--- a/tech-committee-charter.md
+++ b/tech-committee-charter.md
@@ -26,7 +26,7 @@ No more than one-fourth (25%) of the TC members may be affiliated with the same 
 
 The TC may, at its discretion, invite any number of non-voting observers to participate in the public portion of TC discussions and meetings.
 
-The TC shall meet regularly using tools that enable participation by the community. The meeting shall be directed by a rotating TC member.
+The TC shall meet regularly using tools that enable participation by the community. The meeting shall be directed by a rotating TC member. TC members are expected to regularly participate in TC activities.
 
 In the case where an individual TC member -- within any six month period -- attends fewer than 25% of the regularly scheduled meetings, does not participate in TC discussions, and does not participate in TC votes, the member shall be automatically removed from the TC. The member may be invited to continue attending TC meetings as an observer.
 

--- a/tech-committee-charter.md
+++ b/tech-committee-charter.md
@@ -26,7 +26,7 @@ No more than one-fourth (25%) of the TC members may be affiliated with the same 
 
 The TC may, at its discretion, invite any number of non-voting observers to participate in the public portion of TC discussions and meetings.
 
-The TC shall meet regularly using tools that enable participation by the community The meeting shall be directed by the TC Chairperson. Responsibility for directing individual meetings may be delegated by the TC Chairperson to any other TC member. TC members are expected to regularly participate in TC activities.
+The TC shall meet regularly using tools that enable participation by the community. The meeting shall be directed by a rotating TC member.
 
 In the case where an individual TC member -- within any six month period -- attends fewer than 25% of the regularly scheduled meetings, does not participate in TC discussions, and does not participate in TC votes, the member shall be automatically removed from the TC. The member may be invited to continue attending TC meetings as an observer.
 
@@ -105,17 +105,6 @@ New TC members can be nominated by any Member in Standing as defined in the [Ope
 * Vote against Nominee X
 
 The voting should remain open for a minimum of 5 business days.
-
-### Election of TC Chair
-
-The TC will elect from amongst voting TC members a TC Chairperson to work on building an agenda for TC meetings. The TC shall hold annual elections to select a TC Chairperson; there are no limits on the number of terms a TC Chairperson may serve.
-
-For election of persons (such as the TC Chairperson) by a vote of the TC voting members, a multiple-candidate method should be used, such as:
-
-* [Condorcet](https://en.wikipedia.org/wiki/Condorcet_method) or
-* [Single Transferable Vote](https://en.wikipedia.org/wiki/Single_transferable_vote)
-
-Multiple-candidate methods may be reduced to simple election by plurality when there are only two candidates for one position to be filled. No election is required if there is only one candidate and no objections to the candidates election. Elections shall be done within the Projects by the collaborators active in the Project.
 
 ## Voting on project issues
 


### PR DESCRIPTION
The Technical committee has not operated with a chair since its founding. We have recently set up a rotation schedule for running both the Specification and TC meetings which has been performing the duties of the TC chair in our charter.

This PR simply removes the TC Chair position and denotes this rotational responsibility.

If we decide we want/need  chair position going forward we can add it back later.