### PR TITLE
[chore] Clarify that Google Cloud credentials are the same as Google Workspace account

### DIFF
--- a/assets.md
+++ b/assets.md
@@ -84,7 +84,7 @@ Link: https://cloud.google.com
 
 - Community account to host https://go.opentelemetry.io
 - Admin: [@austinlparker](https://github.com/austinlparker)
-  (password is available in the OpenTelemetry Governance 1Password, it is the same as admin@opentelemetry.io "Google Workspace account")
+  (password is the same as admin@opentelemetry.io "Google Workspace account", available in the OpenTelemetry Governance 1Password)
 
 ### Grafana organization for SIG Security
 


### PR DESCRIPTION
There was some initial confusion on my side with this when dealing with open-telemetry/opentelemetry-go-vanityurls/issues/81. This clarifies that the Google Cloud account is the same as the Google Workspace account.