### PR TITLE
Fix link to OpenTelemetry Bot user documentation

### DIFF
--- a/docs/using-github-extensions.md
+++ b/docs/using-github-extensions.md
@@ -21,7 +21,7 @@ Extensions, apps, or bots that can **arbitrarily modify code are NOT allowed**. 
 Many GitHub Action workflows do not require a dedicated GitHub account. Good examples are stale PR checks such as [the one used in semantic convention repo](https://github.com/open-telemetry/semantic-conventions/blob/main/.github/workflows/stale-pr.yml).
 
 If your workflow does require a dedicated GitHub account, you should use [@opentelemetrybot](https://github.com/opentelemetrybot).
-See [OpenTelemetry Bot documentation](../assets.md#opentelemetry-bot) for more details.
+See [OpenTelemetry Bot documentation](../assets.md#opentelemetrybot-github-user) for more details.
 
 ## Creating your own GitHub extensions for OpenTelemetry
 


### PR DESCRIPTION
Updated link reference for OpenTelemetry Bot documentation.

This should fix the failing `markdown-link-check`.

Follow-up on #3011.

cc @trask