### PR TITLE
Remove Josh MacDonald from TC emeritus section

### DIFF
--- a/community-members.md
+++ b/community-members.md
@@ -197,6 +197,5 @@ Repo: [open-telemetry/opentelemetry-demo](https://github.com/open-telemetry/open
 
 ## Technical Committee Emeritus
 
-- [Josh MacDonald](https://github.com/jmacd)
 - [Sergey Kanzhelev](https://github.com/SergeyKanzhelev)
 - [Yuri Shkuro](https://github.com/yurishkuro)


### PR DESCRIPTION
Follow-up from @arminru's https://github.com/open-telemetry/community/pull/3040#discussion_r2395278133