### PR TITLE
[elections/2025] Remove previous account from GC voter list

### DIFF
--- a/elections/2025/voters-roll.csv
+++ b/elections/2025/voters-roll.csv
@@ -120,7 +120,6 @@ chengchuanpeng,31
 chenlujjj,139
 ChrisLightfootWild,288
 ChristianCiach,40
-christophe-kamphaus-jemmic,236
 christos68k,1178
 ChrsMark,1369
 chukunx,20


### PR DESCRIPTION
After leaving Jemmic I no longer have access to the @christophe-kamphaus-jemmic GitHub account and I'm only using @kamphaus.