### PR TITLE
Update GC member onboarding template

### DIFF
--- a/.github/ISSUE_TEMPLATE/gc_member_onboarding.md
+++ b/.github/ISSUE_TEMPLATE/gc_member_onboarding.md
@@ -80,15 +80,18 @@ The new member must:
 - [ ] Create a [CNCF Slack](https://slack.cncf.io/) account if they do not
   already have one.
 
-### CNCF Service Desk
+### CNCF Service Desk and Mailing Lists
 Interactions between the OpenTelemetry GC and CNCF are mostly driven via Service
 Desk tickets. Members can create tickets to discuss access to systems, licensing,
 funds, marketing, press, etc.
 
 The existing member must:
 
-- [ ] Create a Service Desk ticket to invite new member via email and add it to
-  OpenTelemetry group.
+- [ ] Send an email to cncf-maintainer-changes@cncf.io to request invitations to the Service Desk
+      and mailing lists for the new member
+      - https://lists.cncf.io/g/cncf-opentelemetry-governance (moderator)
+      - https://lists.cncf.io/g/cncf-opentelemetry-announce (moderator)
+      - https://lists.cncf.io/g/cncf-opentelemetry-maintainers (member)
 
 The new member must:
 
@@ -96,6 +99,20 @@ The new member must:
 - [ ] Validate they have access to the [CNCF Service Desk](https://cncfservicedesk.atlassian.net/servicedesk/customer/portals)
   (see more information about Service Desk in the [docs](https://github.com/cncf/servicedesk#readme)).
 - [ ] Validate they have access to [OpenTelemetry Requests](https://cncfservicedesk.atlassian.net/servicedesk/customer/user/requests?page=1&reporter=org-31).
+- [ ] Accept invitations to mailing lists above, creating an account on https://lists.cncf.io
+  if necessary, using their preferred email address.
+
+### Additional Mailing List
+
+The existing member must:
+
+- [ ] Invite new member as `Moderator`, ensuring that they have the same
+  privileges as existing members, to the following mailing list:
+  - https://lists.cncf.io/g/cncf-otel-zoomadmins
+
+The new member must:
+- [ ] Accept invitations to mailing list above, creating an account on https://lists.cncf.io
+  if necessary, using their preferred email address.
 
 ### GitHub
 Most of the management, enablement, support and documentation work done by GC
@@ -110,23 +127,6 @@ The existing member must:
 - [ ] Add new member as code owner in [open-telemetry/community](https://github.com/open-telemetry/community/blob/main/CODEOWNERS)
 - [ ] Add new member to the list of GC members in [open-telemetry/community/community-members.md](https://github.com/open-telemetry/community/blob/main/community-members.md).
 - [ ] Add new member in the `OpenTelemetry (Governance Committee)` section of [cncf/foundation/project-maintainers.csv](https://github.com/cncf/foundation/blob/main/project-maintainers.csv)
-
-### Mailing Lists
-The following mailing lists ensure that communications reach all necessary
-members of this group.
-
-The existing member must:
-
-- [ ] Invite new member as `Moderator`, ensuring that they have the same
-  privileges as existing members, to the following mailing lists:
-  - https://lists.cncf.io/g/cncf-opentelemetry-governance
-  - https://lists.cncf.io/g/cncf-otel-zoomadmins
-- [ ] Open CNCF Service Desk ticket to invite new member as `Member` to 
-  https://lists.cncf.io/g/cncf-opentelemetry-maintainers
-
-The new member must:
-- [ ] Accept invitations to mailing lists above, creating an account on https://lists.cncf.io
-  if necessary, using their preferred email address.
 
 ### Google Drive
 OpenTelemetry handles minutes and other ad-hoc documents in Google Drive.


### PR DESCRIPTION
Based on https://github.com/cncf/foundation/pull/1172, looks like there's a new (or at least preferred) process:

> - [ ] You've sent an email with the email address(es) to [cncf-maintainer-changes@cncf.io](mailto:cncf-maintainer-changes@cncf.io) for invitations to Service Desk and mailing lists.

