### PR TITLE
Add recommendation to disclose LLM/GenAI usage.

### DIFF
--- a/policies/genai.md
+++ b/policies/genai.md
@@ -61,8 +61,7 @@ meets project standards, follows established policies, and contributes meaningfu
 to the OpenTelemetry project.
 
 To help foster transparency and collaboration, a human who contributes content that
-was primarily created by generative AI tools should freely and openly disclose this fact
-in advance.
+was primarily created by generative AI tools should freely and openly disclose this fact.
 
 ## Frequently Asked Questions - Contributors
 


### PR DESCRIPTION
I think it's important for maintainers to know when contributions are created using GenAI tools. This PR adds some guidance to the genai.md policy:

* authors should willfully disclose when genai tools have been used to create the bulk of a contribution.
* maintainers may ask if submissions are created with genai.