### PR TITLE
Fix link check failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ table-check:
 markdown-link-check:
 	docker run --rm \
 		--mount 'type=bind,source=$(PWD),target=/home/repo' \
+		-e GITHUB_TOKEN \
 		lycheeverse/lychee:sha-8222559@sha256:6f49010cc46543af3b765f19d5319c0cdd4e8415d7596e1b401d5b4cec29c799 \
 		--config home/repo/.lychee.toml \
 		--root-dir /home/repo \


### PR DESCRIPTION
We were already passing the env var from the link check workflow, just forgot to pass it along to the docker container.

Here's an example failure: https://github.com/open-telemetry/community/actions/runs/19650647766/job/56276603067?pr=3167

```
   [WARN ] There were issues with GitHub URLs. You could try setting a GitHub token and running lychee again.

Issues found in 1 input. Find details below.

[home/repo/governance-charter.md]:
[503] https://github.com/cncf/toc/blob/main/projects/open-telemetry/otel-sandbox-proposal.adoc | Rejected status code (this depends on your "accept" configuration): Service Unavailable
```
