### PR TITLE
Clarify TC donation, stability review timeline and expectations

### DIFF
--- a/.github/ISSUE_TEMPLATE/stabilization-review.md
+++ b/.github/ISSUE_TEMPLATE/stabilization-review.md
@@ -49,6 +49,8 @@ It is ideal to perform a stabilization review before a release candidate is gene
 -->
 
 ## 5. Self-checklist
+
+- [ ] I understand the [TC review process](../../guides/contributor/processes.md#tc-stability-review) and commit to being responsive to any requests for assistance and to issues opened during the review. 
 - [ ] All **MUST / MUST NOT** requirements implemented
 - [ ] [Spec compliance matrix](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix.md) populated and up-to-date
 - [ ] Docs & examples updated

--- a/guides/contributor/donations.md
+++ b/guides/contributor/donations.md
@@ -8,13 +8,7 @@ Donations of preexisting code fall into two broad categories:
   ongoing maintenance of their own, and/or introduce nuanced licensing issues
 
 Large donations – or small donations that turn up complex issues during PR
-review – should be referred to the Technical Committee (TC) by filing an issue
-in this `community` repository and tagging
-`@open-telemetry/technical-committee`. The TC will respond to donation
-proposals **within two weeks** (that is, after having time to meet and discuss
-live). If the TC has not responded to the donation request within that
-interval, the donating party can and should point to this document and request
-guidance at the TC's earliest convenience.
+review – should follow the [donation process](#donation-process).
 
 All donated code requires a license compatible with the Apache Software License
 2.0, and donated code will require a change of copyright to reflect the
@@ -27,8 +21,10 @@ decision to either remove those trademarks or transfer them to the CNCF.
 Broadly, these are the steps the OpenTelemetry Governance and Technical
 Committees follow to handle a prospective donation.
 
-1. Per the above, the donating organization creates a GitHub issue using
-   the "Donation Proposal" form in the `community` repository.
+1. The donating organization creates a GitHub issue using the "Donation
+   Proposal" form in the `community` repository. Various steps in this process
+   involve back and forth communication with the donating organization,
+   which is expected to be engaged and responsive.
 2. The GC will evaluate the proposal to ensure that
    the donation is aligned with the overall OpenTelemetry project vision
    and roadmap and has a balanced set of interested contributors and maintainers.
@@ -45,11 +41,13 @@ Committees follow to handle a prospective donation.
    integrated into the OpenTelemetry project in a way that meets the quality, security,
    and privacy standards of the project without violating stable specification or OpenTelemetry Enhancement Proposals (OTEPs).
    The TC will summarize their findings, and make a recommendation to either
-   accept or reject the proposal, conditionally or unconditionally, in a report which will
-   be attached to the donation proposal issue. Writing the report may require meeting
-   and discussing alternative technologies with different vendors in the community and
-   can be a lengthy process. The TC member driving the report will post updates and time
-   estimates to the issue.
+   accept or reject the proposal, conditionally or unconditionally, in a report
+   which will be attached to the donation proposal issue. Writing the report may
+   require meeting and discussing alternative technologies with different
+   vendors. The amount of time for the TC member to produce the report varies based
+   on the complexity of the donation, existing competing priorities, and other
+   factors. However, generally TC members should aim to produce the initial
+   report within a month or begin providing regular status updates on the issue.
 4. The GC will consider the report and make a final decision about the donation,
    and document that decision on the donation proposal issue.
 5. If accepted, the contributing organization – particularly if it's a

--- a/guides/contributor/processes.md
+++ b/guides/contributor/processes.md
@@ -189,6 +189,22 @@ nuances:
 Note: if your pull request isn't getting enough attention, you can explicitly
 mention approvers or maintainers of this repository.
 
+## TC Stability Review
+
+Language implementation maintainers
+may [request a TC review](../../.github/ISSUE_TEMPLATE/stabilization-review.md)
+prior to stabilizing major areas. The TC should review these requests during the
+regular TC meetings, and promptly assign a member as responsible for the review.
+The assigned TC member will engage with the SDK, supporting resources (e.g.
+docs / examples), and maintainers, and will provide feedback in the form of
+issues on the respective repository. The amount of time for the TC member to
+report feedback varies, but TC members should aim to produce initial feedback
+within a month or begin providing status updates on the issue. During the review
+process, the maintainers of the respective language SDK are expected to be
+responsive to any requests for assistance and to issues opened. In other words,
+a TC stability review is a dialogue requiring engagement from both the TC and
+language SDK maintainers.
+
 ## Code attribution and licensing
 
 [License information](../../README.md#license) should be included in all source files where applicable.

--- a/tech-committee-charter.md
+++ b/tech-committee-charter.md
@@ -35,7 +35,7 @@ In the case where an individual TC member -- within any six month period -- atte
 The TC is responsible for all technical development within the OpenTelemetry project, including:
 
 * Setting release dates
-* Quality standards for releases
+* Quality standards for releases, including [stability reviews](guides/contributor/processes.md#tc-stability-review)
 * Technical direction
 * Development process and any coding standards
 * Approving changes to any specifications


### PR DESCRIPTION
During the 1/21/26 TC meeting, we discussed TC review expectations for both donation proposals and stability reviews, and agreed that it would be useful to clarify a few points:

- For both donations and stability reviews, timelines vary, but the TC should generally aim to provide feedback within a month after assignment. If not practical for any reasons (e.g. complexity, competing priorities) the TC member should begin providing regular updates on the respective issue.
- For both donations and stability reviews, clarify expectations the expectation of a dialogue, where both the TC member and donating org / requesting maintainer are expected to be engaged / responsive. 

To make these clarifications, this PR:

- Adds a new entry in `processes.md` defining the TC stability review process. This is currently implicit - making it explicit gives us a place to write about it. Include guidance on timelines.
- Link to the TC stability review process in the `tech-commitee-charter.md` document as a part of the responsibilities section
- Extends the stabilization review template with a checkbox for the maintainer to indicate they understand the dialogue aspect of the TC review process
- Update `donations.md` file to include guidance on timelines, and clarify the expectation that the donating org is responsive through the process.

cc @open-telemetry/technical-committee 