### PR TITLE
ci: add workflow concurrency to stale action to prevent overlapping runs

### DIFF
--- a/.github/workflows/issue-management-stale-action.yml
+++ b/.github/workflows/issue-management-stale-action.yml
@@ -5,14 +5,18 @@ on:
     # Hourly at minute 23
     - cron: "23 * * * *"
 
+concurrency:
+  group: stale-${{ github.repository }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
 jobs:
   stale:
     permissions:
-      issues: write  # for actions/stale to close stale issues
-      pull-requests: write  # for actions/stale to close stale PRs
+      issues: write # for actions/stale to close stale issues
+      pull-requests: write # for actions/stale to close stale PRs
     runs-on: ubuntu-latest
     steps:
       - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0


### PR DESCRIPTION
#### Description

Add workflow-level concurrency to the stale issue management workflow to prevent overlapping scheduled runs.

This ensures only one stale job runs at a time per repository, which helps avoid duplicate stale comments, conflicting label updates, and unnecessary GitHub Actions usage.

#### Link to tracking issue

N/A

#### Testing

Validated the workflow YAML update.
Confirmed the concurrency block is defined at the workflow level and applies to the scheduled stale job.

