### PR TITLE
Ensure projects are reviewed promptly

### DIFF
--- a/.github/workflows/proposal-triage.yml
+++ b/.github/workflows/proposal-triage.yml
@@ -1,4 +1,4 @@
-name: Issue management - Triage Proposals
+name: Issue management - Triage Project Proposals
 
 on:
   pull_request:

--- a/.github/workflows/proposal-triage.yml
+++ b/.github/workflows/proposal-triage.yml
@@ -1,0 +1,39 @@
+name: Issue management - Triage Proposals
+
+on:
+  pull_request:
+    types: [opened, reopened]
+    paths:
+      - 'projects/**'
+
+permissions:
+  contents: read
+
+jobs:
+  triage:
+    permissions:
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for reviewed label
+        id: check_label
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          labels=$(gh pr view $PR_NUMBER --repo $REPO --json labels --jq '.labels[].name')
+          if echo "$labels" | grep -q "triage:tc-reviewed"; then
+            echo "should_triage=false" >> $GITHUB_OUTPUT
+          else
+            echo "should_triage=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Add TC review label
+        if: steps.check_label.outputs.should_triage == 'true'
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh pr edit $PR_NUMBER --repo $REPO --add-label "triage:tc-inbox"

--- a/project-management.md
+++ b/project-management.md
@@ -100,6 +100,7 @@ Project leads should use it to plan work and communicate status updates to the c
 The project lifecycle is as follows:
 
 * A **Project Proposal** pull request is created, as described above. The pull request should be labeled as `area/project-proposal`, which opens it up for community review.
+  * Upon submission the `triage:tc-inbox` label will be applied. The technical committee will review the project proposal for scope, and technical alignment with other projects or SIGs to determine the appropriate level of sponsorship required. The TC will make comments and add the `triage:tc-reviewed` label when these activities are completed.
   * For a project to be approved, its pull request **must be approved by a majority of GC members**. If a project is approved, and all merge requirements are met, the pull request is merged.
 * One a project is **Approved**, project leads create the corresponding GitHub project and set up meetings and other logistics as documented in the project proposal template.
 * For the duration of the project, project leads, along with their GC liaisons, are expected to regularly (at minimum quarterly) [share project updates](https://docs.github.com/en/issues/planning-and-tracking-with-projects/learning-about-projects/sharing-project-updates) to communicate the status of the project to the wider community. The list of possible statuses any given project is static, and it represents the following:


### PR DESCRIPTION
This updates the project review process.

- Adds automation to place project proposals in the `triage:tc-inbox`
- Add a new label to denote when TC review comments have been places: `triage:tc-reviewed`
- Update project process documentation to denote expectations of what TC will provide during this review and its scope.