### PR TITLE
split workflow to use new token

### DIFF
--- a/.github/workflows/move-to-emeritus.yml
+++ b/.github/workflows/move-to-emeritus.yml
@@ -14,13 +14,6 @@ jobs:
     name: Move inactive members to emeritus
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
-        id: otelbot-token
-        with:
-          app-id: ${{ vars.OTELBOT_APP_ID }}
-          private-key: ${{ secrets.OTELBOT_PRIVATE_KEY }}
-          owner: open-telemetry
-
       - name: Checkout repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -29,7 +22,26 @@ jobs:
         with:
           python-version: '3.12'
 
-      - name: Run move-to-emeritus script
-        run: python scripts/move-to-emeritus.py --create-prs --repo opentelemetry-js opentelemetry-js-contrib opentelemetry-java opentelemetry-java-contrib # Only checking a few repos for now since we want to verify the script works as expected before running it on all repos
+      - uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        id: check-token
+        with:
+          app-id: ${{ vars.OTELBOT_APP_ID }}
+          private-key: ${{ secrets.OTELBOT_PRIVATE_KEY }}
+          owner: open-telemetry
+
+      - name: Check activity and build report
+        run: python -u scripts/move-to-emeritus.py --output /tmp/inactive-report.json
         env:
-          GITHUB_TOKEN: ${{ steps.otelbot-token.outputs.token }}
+          GITHUB_TOKEN: ${{ steps.check-token.outputs.token }}
+
+      - uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        id: pr-token
+        with:
+          app-id: ${{ vars.OTELBOT_APP_ID }}
+          private-key: ${{ secrets.OTELBOT_PRIVATE_KEY }}
+          owner: open-telemetry
+
+      - name: Create PRs from report
+        run: python -u scripts/move-to-emeritus.py --input /tmp/inactive-report.json --create-prs
+        env:
+          GITHUB_TOKEN: ${{ steps.pr-token.outputs.token }}

--- a/.github/workflows/move-to-emeritus.yml
+++ b/.github/workflows/move-to-emeritus.yml
@@ -30,7 +30,7 @@ jobs:
           owner: open-telemetry
 
       - name: Check activity and build report
-        run: python -u scripts/move-to-emeritus.py --output /tmp/inactive-report.json
+        run: python -u scripts/move-to-emeritus.py --output /tmp/inactive-report.json --repo opentelemetry-js opentelemetry-js-contrib opentelemetry-java opentelemetry-java-contrib # Only checking a few repos for now since we want to verify the script works as expected before running it on all repos
         env:
           GITHUB_TOKEN: ${{ steps.check-token.outputs.token }}
 

--- a/scripts/move-to-emeritus.py
+++ b/scripts/move-to-emeritus.py
@@ -873,15 +873,18 @@ def _ensure_branch(repo, branch, base_sha):
     ref_url = f"{REST_API}/repos/{ORG}/{repo}/git/refs/heads/{branch}"
     try:
         request_with_retry("GET", ref_url)
-        # Branch exists — update it
-        request_with_retry("PATCH", ref_url, data={"sha": base_sha, "force": True})
-    except urllib.error.HTTPError:
+    except urllib.error.HTTPError as e:
+        if e.code != 404:
+            raise
         # Branch doesn't exist — create it
         create_url = f"{REST_API}/repos/{ORG}/{repo}/git/refs"
         request_with_retry("POST", create_url, data={
             "ref": f"refs/heads/{branch}",
             "sha": base_sha,
         })
+        return
+    # Branch exists — force-update it
+    request_with_retry("PATCH", ref_url, data={"sha": base_sha, "force": True})
 
 
 def _update_file(repo, path, content, sha, branch, message):
@@ -1059,8 +1062,25 @@ def main():
                         help="Create PRs to move inactive members to emeritus in each repo")
     parser.add_argument("--repo", nargs="+", default=None,
                         help="Only check specific repo(s) (e.g. opentelemetry-python opentelemetry-collector)")
+    parser.add_argument("--output", type=str, default=None,
+                        help="Save the inactive report to a JSON file (skips PR creation)")
+    parser.add_argument("--input", type=str, default=None,
+                        help="Load a previously saved report and create PRs (skips activity checking)")
     args = parser.parse_args()
     DEBUG = args.debug
+
+    # --input: skip activity checking and go straight to PR creation
+    if args.input:
+        with open(args.input) as f:
+            saved = json.load(f)
+        cutoff = saved["cutoff"]
+        inactive_report = {repo: [tuple(e) for e in entries]
+                           for repo, entries in saved["inactive_report"].items()}
+        repo_warnings = saved["repo_warnings"]
+        print(f"Loaded report from {args.input} (cutoff: {cutoff})")
+        if args.create_prs:
+            create_emeritus_prs(inactive_report, repo_warnings, cutoff)
+        return
 
     cutoff = get_cutoff_date()
     print(f"Checking for inactivity since {cutoff} ...\n")
@@ -1083,6 +1103,7 @@ def main():
         keyword = role["keyword"]
         label = role["label"]
 
+        print(f"Fetching {label.lower()} teams...")
         teams = get_teams_by_role(keyword)
         if not teams:
             print(f"No {label.lower()} teams found.\n")
@@ -1092,6 +1113,7 @@ def main():
             slug = team["slug"]
             name = team["name"]
             team_name_lower = name.lower()
+            print(f"  Fetching members and repos for '{name}'...")
             members = get_team_members(slug)
             repos = get_team_repos(slug, cutoff)
 
@@ -1265,6 +1287,17 @@ def main():
         total_inactive += len(user_info)
 
     print(f"\nTotal: {total_inactive} inactive member(s) across repo(s)")
+
+    # Save report to file if requested
+    if args.output:
+        with open(args.output, "w") as f:
+            json.dump({
+                "cutoff": cutoff,
+                "inactive_report": {repo: [list(e) for e in entries]
+                                    for repo, entries in inactive_report.items()},
+                "repo_warnings": repo_warnings,
+            }, f, indent=2)
+        print(f"Report saved to {args.output}")
 
     # Create PRs if requested
     if args.create_prs:


### PR DESCRIPTION
Retrieving activity data takes a long time, so the token kept expiring and the PRs were not being created. This breaks down the workflow into 2, and get a new token when is time to create the PRs.

For this the middle step is now saving the activity to a tmp file, then using the results for the PR creation