### PR TITLE
docs: Add welcoming note above the SIG meetings tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,11 @@ SIG-specific GitHub discussions.
 > The meeting times in the tables below are given in 24-hour notation.
 > Meetings are either in Pacific Time (PT), with Daylight Saving Time, or UTC+8, without Daylight Saving Time.
 
+> [!NOTE]
+> **All SIG meetings listed below are open to anyone.** Whether you're a
+> seasoned OpenTelemetry developer, just starting your journey, or simply
+> curious about the work we do, you are more than welcome to join.
+
 <!-- The tables below are auto-generated. To make changes, see CONTRIBUTING.md#updating-sig-information-on-the-readmemd -->
 <!-- sigs -->
 ### Specification SIGs

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ SIG-specific GitHub discussions.
 
 > [!NOTE]
 > **All SIG meetings listed below are open to anyone.** Whether you're a
-> seasoned OpenTelemetry developer, just starting your journey, or simply
+> seasoned OpenTelemetry contributor, just starting your journey, or simply
 > curious about the work we do, you are more than welcome to join.
 
 <!-- The tables below are auto-generated. To make changes, see CONTRIBUTING.md#updating-sig-information-on-the-readmemd -->


### PR DESCRIPTION
Adds a short `[!NOTE]` callout above the auto-generated SIG meetings tables, making explicit that meetings are open to anyone regardless of experience level. Companion to the wave of small docs PRs adopting similar wording in language SDK READMEs (rust, dotnet, python, cpp, go, otel-arrow, and others). Per discussion in [community#1805](https://github.com/open-telemetry/community/issues/1805) — scoped to the welcoming half only; the separate "meeting → public meeting" rename discussed in #1805 is intentionally out of scope here.