### PR TITLE
Document specification deviation exceptions

### DIFF
--- a/.github/ISSUE_TEMPLATE/stabilization-review.md
+++ b/.github/ISSUE_TEMPLATE/stabilization-review.md
@@ -40,6 +40,7 @@ Delete the guidance comments after filling in the form.
   | … | … | … | … |
   -->
 * **Public docs / getting-started sample:** <link>
+* **Specification deviations:** <link to any approved GC exception and user-facing documentation, or `None`>
 * **CHANGELOG draft:** <link>
 
 <!--
@@ -51,7 +52,7 @@ It is ideal to perform a stabilization review before a release candidate is gene
 ## 5. Self-checklist
 
 - [ ] I understand the [TC review process](../../guides/contributor/processes.md#tc-stability-review) and commit to being responsive to any requests for assistance and to issues opened during the review. 
-- [ ] All **MUST / MUST NOT** requirements implemented
+- [ ] All **MUST**, **MUST NOT**, and **REQUIRED** specification requirements are implemented, except for any [specification deviations](../../guides/contributor/processes.md#specification-deviations) approved by the GC and documented in the component repository
 - [ ] [Spec compliance matrix](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix.md) populated and up-to-date
 - [ ] Docs & examples updated
 - [ ] Test suites passing

--- a/assets.md
+++ b/assets.md
@@ -237,7 +237,7 @@ CNCF are the owners of the group, so certain requests (e.g. adding/removing orga
 * CNCF Service Desk
 * https://github.com/cncf/communitygroups/issues
 
-Link: https://community.cncf.io/opentelemetry/
+Link: https://community.cncf.io/opentelemetry-live/
 
 - Owners: CNCF
 - Lead Organizers (i.e. admins):

--- a/guides/contributor/processes.md
+++ b/guides/contributor/processes.md
@@ -21,6 +21,8 @@ help, and how changes are merged and released.
   - [GitHub workflow](#github-workflow)
   - [Open a Pull Request](#open-a-pull-request)
   - [Code Review](#code-review)
+  - [TC Stability Review](#tc-stability-review)
+    - [Specification deviations](#specification-deviations)
   - [Code attribution and licensing](#code-attribution-and-licensing)
     - [Copyright Notices](#copyright-notices)
   - [Specification Changes](#specification-changes)
@@ -204,6 +206,24 @@ process, the maintainers of the respective language SDK are expected to be
 responsive to any requests for assistance and to issues opened. In other words,
 a TC stability review is a dialogue requiring engagement from both the TC and
 language SDK maintainers.
+
+### Specification deviations
+
+Stable OpenTelemetry components are expected to satisfy all **MUST**,
+**MUST NOT**, and **REQUIRED** specification requirements. If maintainers believe
+a required part of the specification should not be implemented for a component,
+the exception is a product decision owned by the
+[Governance Committee](../../governance-charter.md), not only a
+component-specific decision.
+
+Specification exceptions are not recommended, but may be granted by the
+Governance Committee after review, discussion, and vote. This review and
+discussion may include recommendations from the Technical Committee,
+maintainers, or other SIGs.
+
+If an exception is granted, the component repository must document the deviation
+and make it clear to users. The Governance Committee may remove an exception if
+circumstances change, using similar review rigor.
 
 ## Code attribution and licensing
 


### PR DESCRIPTION
Closes #2097.

## Summary

- Document that GC-approved specification exceptions may apply during stability review.
- Update the stabilization review template so requesters disclose approved deviations and user-facing documentation.

## Testing

- `npx cspell --config .cspell.yaml guides/contributor/processes.md .github/ISSUE_TEMPLATE/stabilization-review.md`
- `git diff --check`
- `docker run --rm --mount \"type=bind,source=$(pwd),target=/home/repo\" -e GITHUB_TOKEN lycheeverse/lychee:sha-8222559@sha256:6f49010cc46543af3b765f19d5319c0cdd4e8415d7596e1b401d5b4cec29c799 --config home/repo/.lychee.toml --root-dir /home/repo --verbose home/repo/guides/contributor/processes.md home/repo/.github/ISSUE_TEMPLATE/stabilization-review.md`