### PR TITLE
Add steps for promotion for triager and approver

### DIFF
--- a/guides/contributor/membership.md
+++ b/guides/contributor/membership.md
@@ -125,14 +125,47 @@ elsewhere on GitHub.
 
 ### Requirements
 
-- Nominated by a maintainer, with no objections from other maintainers.
-- Consistently interact with the community and help with issues for at least 1 month.
+- Has been performing the role's responsibilities (see below), within the
+  access they have, for at least 1 month.
 
 ### Responsibilities and privileges
 
 - Have an understanding of the goals and workflows defined by the maintainers.
 - Respond to new PRs and Issues by asking clarifying questions.
 - Organize the backlog by applying labels, milestones, assignees, and projects.
+
+### Becoming a Triager
+
+Unless stated otherwise in a SIG charter ratified by the Technical Committee,
+a new triager is elected by vote of the existing maintainers of the SIG.
+The vote is officially started when a pull request to add a new triager
+is opened, and ends when the pull request is merged. The pull request body
+should include links to the nominee's relevant activity. The pull request may
+be merged when the following conditions are met:
+
+- The person being nominated has accepted the nomination by approving the pull request
+- All maintainers have approved the pull request OR a majority of maintainers
+  have approved the pull request and no maintainer has objected by requesting
+  changes on the pull request. In the case that all maintainers have not given
+  approval, the pull request should stay open for a minimum of 5 days before merging.
+
+Existing triagers and approvers may also leave reviews on the pull request as
+a signal of support, but the merge condition is determined by maintainer
+approvals.
+
+The nominee is considered a triager after the pull request is merged.
+
+#### Self-nomination is encouraged
+
+If you feel like you meet the requirements above and are willing to take on
+the additional responsibilities and privileges of being a triager, it is
+recommended that you approach an existing maintainer about sponsoring your
+bid to become a triager. After you and your sponsor have discussed the role
+and its additional requirements and responsibilities, they may approach the
+other maintainers about a vote to confirm you as a new triager. If the
+maintainer does not believe you are ready for the role, or the subproject is
+not in need of additional triagers, they may suggest growth areas in order to
+improve your chances to become a triager in the future.
 
 ## Approver
 
@@ -165,13 +198,11 @@ elsewhere on GitHub.
 The following apply to the part of the codebase for which one would be an
 approver in the `CODEOWNERS` files.
 
-- Reviewer of the codebase for at least 1 month
-- Reviewer for or author of at least 10 substantial PRs to the codebase,
+- Has been performing the role's responsibilities (see below), within the
+  access they have, for at least 1 month.
+- Has reviewed or authored at least 10 substantial PRs to the codebase,
   with the definition of substantial subject to the maintainer's discretion
   (e.g. refactors/adds new functionality rather than one-line pulls).
-- Nominated by a maintainer
-  - With no objections from other maintainers
-  - Done through PR to update the `CODEOWNERS`.
 
 ### Responsibilities and privileges
 
@@ -187,6 +218,38 @@ approver in the `CODEOWNERS` files.
 - Expected to be responsive to review requests (inactivity for more than 1 month may result in suspension until active again)
 - Mentor contributors and reviewers
 - May approve code contributions for acceptance
+
+### Becoming an Approver
+
+Unless stated otherwise in a SIG charter ratified by the Technical Committee,
+a new approver is elected by vote of the existing maintainers of the SIG.
+The vote is officially started when a pull request to add a new approver
+is opened, and ends when the pull request is merged. The pull request body
+should include links to the nominee's relevant activity. The pull request may
+be merged when the following conditions are met:
+
+- The person being nominated has accepted the nomination by approving the pull request
+- All maintainers have approved the pull request OR a majority of maintainers
+  have approved the pull request and no maintainer has objected by requesting
+  changes on the pull request. In the case that all maintainers have not given
+  approval, the pull request should stay open for a minimum of 5 days before merging.
+
+Existing approvers may also leave reviews on the pull request as a signal of
+support, but the merge condition is determined by maintainer approvals.
+
+The nominee is considered an approver after the pull request is merged.
+
+#### Self-nomination is encouraged
+
+If you feel like you meet the requirements above and are willing to take on
+the additional responsibilities and privileges of being an approver, it is
+recommended that you approach an existing maintainer about sponsoring your
+bid to become an approver. After you and your sponsor have discussed the
+role and its additional requirements and responsibilities, they may approach
+the other maintainers about a vote to confirm you as a new approver. If the
+maintainer does not believe you are ready for the role, or the subproject is
+not in need of additional approvers, they may suggest growth areas in order
+to improve your chances to become an approver in the future.
 
 ## Maintainer
 


### PR DESCRIPTION
Proposed fix for https://github.com/open-telemetry/sig-contributor-experience/issues/13
This file has gone a long way since the issue has been opened so some of it has been resolved organically. This is just formalising the process for promoting people to triager or approver, which inpractice has been pretty similar to the one for maintainers. 
This should add some clarity on what maintainers should expect from a nominated person in order to approve the promotion, and also for contributors to know when they should start a discussion in that direction. 

I ve made the decision (which is what i have observed and also follows other OSS projects) that for triagers and approvers we should only count maintainer votes. I'd be happy to change it to include approvers if anyone thinks it should be that way. 

Im still a bit confused about the approver-codeowner thing since from what i've seen in collector contrib at least they are different concepts, but that may be a different issue or just me understanding things wrong. 