### PR TITLE
fix: update README SIG table of contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Table of Contents
 * [Special Interest Groups](#special-interest-groups)
   * [Specification SIGs](#specification-sigs)
   * [Implementation SIGs](#implementation-sigs)
+  * [Cross-Cutting SIGs](#cross-cutting-sigs)
+  * [Localization Teams (part of SIG Communications)](#localization-teams-part-of-sig-communications)
 * [Related groups](#related-groups)
   * [W3C - Distributed Tracing Working Group](#w3c---distributed-tracing-working-group)
   * [Erlang Ecosystem Foundation – Observability Working Group](#erlang-ecosystem-foundation--observability-working-group)


### PR DESCRIPTION
Small README papercut, no biggie.

Repro:
1. Open the README table of contents.
2. Under Special Interest Groups, only Specification and Implementation are linked.
3. Scroll down: Cross-Cutting SIGs and Localization Teams are real sections, but missing from the TOC.

Fix: add the two missing links. GitHub anchors resolve to `#cross-cutting-sigs` and `#localization-teams-part-of-sig-communications`.

Checks:
- `python3 scripts/update-sig-tables.py --check`
- `python3 scripts/update-community-members.py --check`
- `python3 scripts/validate-workstreams.py`
- `git diff --check`

No cloud/API quota angle here, afaict; this is plain GitHub Markdown navigation, so anyone reading the README can hit it.