### PR TITLE
Clarify repo admin process

### DIFF
--- a/docs/how-to-configure-new-repository.md
+++ b/docs/how-to-configure-new-repository.md
@@ -57,11 +57,10 @@ If the repository is using the Project Boards, `foo-triagers` should have
 `foo-triagers` to the CODEOWNERS file, as their approvals should not count
 towards the required number of approvals for merging.
 
-If requested, `foo-maintainers` will be granted `Admin` permissions, and in return
-they must document any changes they make to the repository settings in a file named
-`.github/repository-settings.md` in their repository (other than temporarily
-disabling "Do not allow bypassing the above settings", see branch protection rules
-below).
+There are cases when maintainers want to request for `Admin` permissions. Please
+check the [request repository admin
+permissions](../guides/maintainer/github-admin-processes.md#request-repository-admin-permissions)
+guideline.
 
 ### Branches
 

--- a/guides/maintainer/github-admin-processes.md
+++ b/guides/maintainer/github-admin-processes.md
@@ -78,10 +78,12 @@ There are cases when the maintains would want to have `Admin` permission:
   security advisories.
 
 Maintainers can request `Admin` permissions by the
-[open-telemetry/admin](https://github.com/open-telemetry/admin) PR process, here
-is [an example](https://github.com/open-telemetry/admin/pull/639). If requested,
-the maintainer will be granted `Admin` permissions, and in return they must
-document any changes they make to the repository settings in a file named
+[open-telemetry/admin](https://github.com/open-telemetry/admin) PR process and
+get approval from one other repository maintainer (approval from a GitHub Org
+Admin is not required). Here is [an
+example](https://github.com/open-telemetry/admin/pull/639). If requested, the
+maintainer will be granted `Admin` permissions, and in return they must document
+any changes they make to the repository settings in a file named
 `.github/repository-settings.md` in their repository (other than temporarily
 disabling "Do not allow bypassing the above settings", see branch protection
 rules below).

--- a/guides/maintainer/github-admin-processes.md
+++ b/guides/maintainer/github-admin-processes.md
@@ -80,8 +80,8 @@ There are cases when the maintainers would want to have `Admin` permission:
 Maintainers can request `Admin` permissions by the
 [open-telemetry/admin](https://github.com/open-telemetry/admin) PR process and
 get approval from one other repository maintainer (approval from a GitHub Org
-Admin is not required). Here is [an
-example](https://github.com/open-telemetry/admin/pull/639). If requested, the
+Admin is not required). Follow the steps documented [here](https://github.com/open-telemetry/admin#need-temporary-admin-rights).
+If requested, the
 maintainer will be granted `Admin` permissions, and in return they must document
 any changes they make to the repository settings in a file named
 `.github/repository-settings.md` in their repository (other than bypassing

--- a/guides/maintainer/github-admin-processes.md
+++ b/guides/maintainer/github-admin-processes.md
@@ -80,10 +80,10 @@ There are cases when the maintainers would want to have `Admin` permission:
 Maintainers can request temporary or permanent `Admin` permissions by the
 [open-telemetry/admin](https://github.com/open-telemetry/admin) PR process and
 get approval from one other repository maintainer (approval from a GitHub Org
-Admin is not required). Follow the steps documented [here](https://github.com/open-telemetry/admin#need-temporary-admin-rights).
-If requested, the
-maintainer will be granted `Admin` permissions, and in return they must document
-any changes they make to the repository settings in a file named
-`.github/repository-settings.md` in their repository (other than bypassing
+Admin is not required). Follow the steps documented
+[here](https://github.com/open-telemetry/admin#need-temporary-admin-rights). If
+requested, the maintainer will be granted `Admin` permissions, and in return
+they must document any changes they make to the repository settings in a file
+named `.github/repository-settings.md` in their repository (other than bypassing
 branch protection rules in order to merge a security fix from a temporary
 private fork).

--- a/guides/maintainer/github-admin-processes.md
+++ b/guides/maintainer/github-admin-processes.md
@@ -63,3 +63,25 @@ For changes affecting a single repository owned by a single SIG:
   Changes that affect a single repository owned by multiple SIGs should follow the same
   process, but the change should have the approval of at least one maintainer from each
   affected SIG.
+
+### Request Repository Admin Permissions
+
+By default, maintainers of a repository have the `Maintain` permission instead
+of the `Admin` permission. This is to protect the maintainers from making
+accidental/unintended changes that are sensitive and/or destructive.
+
+There are cases when the maintains would want to have `Admin` permission:
+
+- Make necessary changes that are not currently supported by the
+  [open-telemetry/admin](https://github.com/open-telemetry/admin) PR process.
+- Handle (e.g., accept, publish, merge fixes from a private fork/branch, etc.)
+  security advisories.
+
+Maintainers can request `Admin` permissions by the
+[open-telemetry/admin](https://github.com/open-telemetry/admin) PR process, here
+is [an example](https://github.com/open-telemetry/admin/pull/639). If requested,
+the maintainer will be granted `Admin` permissions, and in return they must
+document any changes they make to the repository settings in a file named
+`.github/repository-settings.md` in their repository (other than temporarily
+disabling "Do not allow bypassing the above settings", see branch protection
+rules below).

--- a/guides/maintainer/github-admin-processes.md
+++ b/guides/maintainer/github-admin-processes.md
@@ -77,7 +77,7 @@ There are cases when the maintainers would want to have `Admin` permission:
 - Handle (e.g., accept, publish, merge fixes from a private fork/branch, etc.)
   security advisories.
 
-Maintainers can request `Admin` permissions by the
+Maintainers can request temporary or permanent `Admin` permissions by the
 [open-telemetry/admin](https://github.com/open-telemetry/admin) PR process and
 get approval from one other repository maintainer (approval from a GitHub Org
 Admin is not required). Follow the steps documented [here](https://github.com/open-telemetry/admin#need-temporary-admin-rights).

--- a/guides/maintainer/github-admin-processes.md
+++ b/guides/maintainer/github-admin-processes.md
@@ -70,7 +70,7 @@ By default, maintainers of a repository have the `Maintain` permission instead
 of the `Admin` permission. This is to protect the maintainers from making
 accidental/unintended changes that are sensitive and/or destructive.
 
-There are cases when the maintains would want to have `Admin` permission:
+There are cases when the maintainers would want to have `Admin` permission:
 
 - Make necessary changes that are not currently supported by the
   [open-telemetry/admin](https://github.com/open-telemetry/admin) PR process.
@@ -84,6 +84,6 @@ Admin is not required). Here is [an
 example](https://github.com/open-telemetry/admin/pull/639). If requested, the
 maintainer will be granted `Admin` permissions, and in return they must document
 any changes they make to the repository settings in a file named
-`.github/repository-settings.md` in their repository (other than temporarily
-disabling "Do not allow bypassing the above settings", see branch protection
-rules below).
+`.github/repository-settings.md` in their repository (other than bypassing
+branch protection rules in order to merge a security fix from a temporary
+private fork).


### PR DESCRIPTION
Supersedes #3465

This would help the maintainers to better handle security advisories.

Related to https://github.com/open-telemetry/sig-security/pull/269