### PR TITLE
fix: typo in update-sig-tables.py comment (safe -> save)

### DIFF
--- a/scripts/update-sig-tables.py
+++ b/scripts/update-sig-tables.py
@@ -9,7 +9,7 @@ if (len(sys.argv) > 1) and (sys.argv[1] == "--install"):
 
 import yaml
 
-# Do not safe the file but verify that it is different from the original one.
+# Do not save the file but verify that it is different from the original one.
 run_in_check_mode = (len(sys.argv) > 1) and (sys.argv[1] == "--check")
 
 WORKSTREAMS_FILE = "workstreams.yml"


### PR DESCRIPTION
Small typo on line 12 of `scripts/update-sig-tables.py` - `safe` instead of `save`.

The same comment in `update-community-members.py` has it right, so this was a copy-paste thing that slipped thru