### PR TITLE
Print actionable error message when --check finds stale files

### DIFF
--- a/scripts/update-community-members.py
+++ b/scripts/update-community-members.py
@@ -66,6 +66,7 @@ if run_in_check_mode:
     if original == result:
         sys.exit(0)
     else:
+        print(f"{MARKDOWN_FILE} is out of date. Run 'make generate' to update it.", file=sys.stderr)
         sys.exit(1)
 else:
     with open(MARKDOWN_FILE, "w", encoding="utf-8") as f:

--- a/scripts/update-sig-tables.py
+++ b/scripts/update-sig-tables.py
@@ -171,6 +171,7 @@ if run_in_check_mode:
     if original == result:
         sys.exit(0)
     else:
+        print(f"{markdown_file} is out of date. Run 'make generate' to update it.", file=sys.stderr)
         sys.exit(1)
 else:
     with open(markdown_file, "w", encoding="utf-8") as f:


### PR DESCRIPTION
## Summary

`update-sig-tables.py` and `update-community-members.py` support `--check` mode (used by `make check-generate` in CI). 
When generated file is out of date, they currently exit with code 1 but print no output - leaving developers with only a bare exit-code failure in CI logs and no indication of which file is stale or how to fix it.

This PR adds a one-line `stderr` message in both scripts so failure is self-explanatory:

```
README.md is out of date. Run 'make generate' to update it.
community-members.md is out of date. Run 'make generate' to update it.
```

The success path (exit 0, no output) is unchanged

## Test plan

- [x] `python3 scripts/update-sig-tables.py --check` -> exit 0, no output (files are up to date)
- [x] `python3 scripts/update-community-members.py --check` -> exit 0, no output
- [x] Simulated stale `README.md` -> exit 1 + message on stderr  
- [x] Simulated stale `community-members.md` -> exit 1 + message on stderr 
- [x] `python3 scripts/validate-workstreams.py` still passes
