### PR TITLE
add google play sdk console account to assets

### DIFF
--- a/assets.md
+++ b/assets.md
@@ -170,7 +170,7 @@ Link: <https://accounts.google.com/ServiceLogin?service=androiddeveloper&passive
 
 - SDK is verified via admin@opentelemetry.io
 - Point of contact email is android-maintainers@opentelemetry.io
-- Admin: Android Maintainers
+- Admin: [@open-telemetry/android-maintainers](https://github.com/orgs/open-telemetry/teams/android-maintainers)
 
 ## Artifact repositories
 

--- a/assets.md
+++ b/assets.md
@@ -160,6 +160,18 @@ Link: https://develocity.opentelemetry.io
 - Secret stored in the OpenTelemetry Java 1Password vault
 - Admin: [@trask](https://github.com/trask)
 
+
+### Google Play SDK Console
+
+We have a [Google Play SDK Console](https://play.google.com/sdk-console/about/) for the Android SDK to get
+insights about the SDK.
+
+Link: <https://accounts.google.com/ServiceLogin?service=androiddeveloper&passive=true&continue=https%3A%2F%2Fplay.google.com%2Fsdk-console%2F>
+
+- SDK is verified via admin@opentelemetry.io
+- Point of contact email is android-maintainers@opentelemetry.io
+- Admin: Android Maintainers
+
 ## Artifact repositories
 
 ### NuGet OpenTelemetry organization


### PR DESCRIPTION
Adding details for Google Play SDK Console to assets file. The mailinglist for android maintainers needs to be created.

cc @open-telemetry/android-maintainers 