### PR TITLE
Fix broken community-members.md#specifications-and-proto links

### DIFF
--- a/guides/contributor/membership.md
+++ b/guides/contributor/membership.md
@@ -15,7 +15,7 @@ maintainer!
 | approver              | approve incoming contributions                                    | highly experienced and active reviewer + contributor to a subproject                                                                             | [CODEOWNERS](https://help.github.com/en/articles/about-code-owners) in GitHub                                  |
 | maintainer            | set direction and priorities for a subproject                     | demonstrated responsibility and excellent technical judgement for the subproject                                                                 | [CODEOWNERS](https://help.github.com/en/articles/about-code-owners), GitHub Team and repo ownership in GitHub  |
 | emeritus              | position of honor for former maintainers, approvers, and triagers | must have previously held a community role and not have been removed from that role for a [Code of Conduct](../../code-of-conduct.md) violation. | Listed as an emeritus maintainer/approver/triager in CONTRIBUTING, CODEOWNERS, or README                       |
-| specification sponsor | trusted collaborators for the specification                       | nominated by [Technical Committee][]                                                                                                             | Listed in [Community Members -> Specification and Protos](../../community-members.md#specifications-and-proto) |
+| specification sponsor | trusted collaborators for the specification                       | nominated by [Technical Committee][]                                                                                                             | Listed in the [opentelemetry-specification README](https://github.com/open-telemetry/opentelemetry-specification#approvers)                       |
 
 ## New contributors
 
@@ -382,8 +382,8 @@ Specification sponsors are trusted collaborators of the technical committee, and
 work to review, approve, and sponsor [opentelemetry-specification][] issues and
 PRs.
 
-Members are defined
-in [Community Members -> Specification and Protos](../../community-members.md#specifications-and-proto)
+Members are listed
+in the [opentelemetry-specification README](https://github.com/open-telemetry/opentelemetry-specification#approvers)
 and are members of the `spec-sponsors` team (TODO: add link to github team when
 available). Specification sponsors SHOULD list
 their [areas of interest](../../areas-of-interest.md).


### PR DESCRIPTION
The `Specifications and Proto` section was removed from `community-members.md` in #3513; updating the two callers in `guides/contributor/membership.md` to point at the new location (`opentelemetry-specification#approvers`). Unbreaks `markdown-link-check` CI.