### PR TITLE
Update otelbot workflow approval docs

### DIFF
--- a/assets.md
+++ b/assets.md
@@ -407,13 +407,12 @@ This GitHub App addresses two common issues:
    > [!WARNING]
    > Branch protection rule **ordering** matters, so you will need to delete the `**/**` branch protection rule temporarily, then add the `otelbot/**/*` branch protection rule, then add back the `**/**` branch protection rule.
 
-2. When you use the built-in `secrets.GITHUB_TOKEN` to generate a pull request from inside a [GitHub Action], workflows
-   will not run on that new pull request without closing and re-opening it manually (this limitation is in place to
-   prevent accidental recursive workflow runs).
+2. When you use the built-in `secrets.GITHUB_TOKEN` to generate a pull request from inside a [GitHub Action], workflows on that pull request
+   require approval from a user with write access to the repository before they can run.
 
    The OpenTelemetry GitHub organization has a GitHub Action secret (`OTELBOT_PRIVATE_KEY`)
    and a GitHub Action variable `OTELBOT_APP_ID` that can be used to create a GitHub App token
-   which will bypass this limitation, e.g.
+   which will bypass this manual approval step, e.g.
 
    ```
    - uses: actions/create-github-app-token@v1
@@ -424,7 +423,7 @@ This GitHub App addresses two common issues:
 
    - name: Create pull request
      env:
-       # not using secrets.GITHUB_TOKEN since pull requests from that token do not trigger workflows
+       # using a GitHub App token so workflows run automatically without requiring manual approval
        GH_TOKEN: ${{ steps.app-token.outputs.token }}
      run: ...
    ```


### PR DESCRIPTION
Update the `otelbot` docs for GitHub's June 11 Actions change. Pull requests created with `secrets.GITHUB_TOKEN` can now run CI/CD workflows, with approval required from a user with write access before those workflows run; `otelbot` remains useful when automation should open PRs whose workflows can run without requiring that manual approval step.

The changelog says:

> This change allows all pull requests, even bot-generated changes, to run configured CI/CD workflows if approved by a user with write access to the repository.

https://github.blog/changelog/2026-06-11-bot-created-pull-requests-can-run-workflows-if-approved/