### PR TITLE
[governance-charter.md] Add campaigning guidance section

### DIFF
--- a/governance-charter.md
+++ b/governance-charter.md
@@ -214,7 +214,7 @@ treated as "brand free" activities.
 ### Campaigning guidance
 
 All campaigning must follow the Code of Conduct and community values. In particular,
-it should not be disruptive to the normal functioning of community spaces or take an
+it should not be disruptive to the normal functioning of community spaces or take up an
 excessive amount of time.
 
 Community members, including candidates, are free to campaign under these

--- a/governance-charter.md
+++ b/governance-charter.md
@@ -226,9 +226,9 @@ OpenTelemetry website.
 From the publication of the official list of nominees up until the closing of
 elections, OpenTelemetry-sponsored social media content must not feature or
 promote any particular candidate above others. Additionally, OpenTelemetry
-website publications authored by a candidate in that period must be approved by
-a majority of existing Governance Committee members who are not running in those
-elections.
+website publications (e.g. blog posts) authored by a candidate in that period must
+be approved by a majority of existing Governance Committee members who are not
+running in those elections.
 
 ## Refactoring or reforming the governance committee
 

--- a/governance-charter.md
+++ b/governance-charter.md
@@ -217,11 +217,11 @@ All campaigning must follow the Code of Conduct and community values. In particu
 it should not be disruptive to the normal functioning of community spaces or take an
 excessive amount of time.
 
-Community members, including candidates, are free to campaign under these conditions
-(e.g., ask others to vote for a particular candidate) in community OpenTelemetry
-spaces (e.g., Slack channels, SIG meetings) outside of Github and official,
-public-facing content such as OpenTelemetry-sponsored social media content or the
-OpenTelemetry website.
+Community members, including candidates, are free to campaign under these
+conditions (e.g., ask others to vote for a particular candidate) in some
+community OpenTelemetry spaces (e.g., Slack channels, SIG meetings). Campaigning
+on Github, in OpenTelemetry-sponsored social media content or in the
+OpenTelemetry website is not allowed.
 
 From the publication of the official list of nominees up until the closing of
 elections, OpenTelemetry-sponsored social media content must not feature or

--- a/governance-charter.md
+++ b/governance-charter.md
@@ -219,7 +219,7 @@ excessive amount of time.
 
 Community members, including candidates, are free to campaign under these conditions
 (e.g., ask others to vote for a particular candidate) in community OpenTelemetry
-spaces (e.g., Slack channels, GitHub repos, SIG meetings) outside of official,
+spaces (e.g., Slack channels, SIG meetings) outside of Github and official,
 public-facing content such as OpenTelemetry-sponsored social media content or the
 OpenTelemetry website.
 

--- a/governance-charter.md
+++ b/governance-charter.md
@@ -220,7 +220,7 @@ excessive amount of time.
 Community members, including candidates, are free to campaign under these
 conditions (e.g., ask others to vote for a particular candidate) in some
 community OpenTelemetry spaces (e.g., Slack channels, SIG meetings). Campaigning
-on Github, in OpenTelemetry-sponsored social media content or in the
+on Github, in OpenTelemetry-sponsored social media content or on the
 OpenTelemetry website is not allowed.
 
 From the publication of the official list of nominees up until the closing of

--- a/governance-charter.md
+++ b/governance-charter.md
@@ -211,6 +211,23 @@ their behalf or sponsor candidates from partner organizations. Simply put,
 elections highlight individuals outside of their corporate role and should be
 treated as "brand free" activities.
 
+### Campaigning guidance
+
+Community members, including candidates, are free to campaign (e.g., ask others
+to vote for a particular candidate) in community OpenTelemetry spaces (e.g.,
+Slack channels, GitHub repos, SIG meetings) outside of official, public-facing
+content such as OpenTelemetry-sponsored social media content or the
+OpenTelemetry website.
+
+From the publication of the official list of nominees up until the closing of
+elections, OpenTelemetry-sponsored social media content must not feature or
+promote any particular candidate above others. Additionally, OpenTelemetry
+website publications authored by a candidate in that period must be approved by
+a majority of existing Governance Committee members who are not running in those
+elections.
+
+All campaigning must follow the Code of Conduct and community values.
+
 ## Refactoring or reforming the governance committee
 
 At any time the governance committee may vote, via supermajority (greater than

--- a/governance-charter.md
+++ b/governance-charter.md
@@ -213,10 +213,14 @@ treated as "brand free" activities.
 
 ### Campaigning guidance
 
-Community members, including candidates, are free to campaign (e.g., ask others
-to vote for a particular candidate) in community OpenTelemetry spaces (e.g.,
-Slack channels, GitHub repos, SIG meetings) outside of official, public-facing
-content such as OpenTelemetry-sponsored social media content or the
+All campaigning must follow the Code of Conduct and community values. In particular,
+it should not be disruptive to the normal functioning of community spaces or take an
+excessive amount of time.
+
+Community members, including candidates, are free to campaign under these conditions
+(e.g., ask others to vote for a particular candidate) in community OpenTelemetry
+spaces (e.g., Slack channels, GitHub repos, SIG meetings) outside of official,
+public-facing content such as OpenTelemetry-sponsored social media content or the
 OpenTelemetry website.
 
 From the publication of the official list of nominees up until the closing of
@@ -225,8 +229,6 @@ promote any particular candidate above others. Additionally, OpenTelemetry
 website publications authored by a candidate in that period must be approved by
 a majority of existing Governance Committee members who are not running in those
 elections.
-
-All campaigning must follow the Code of Conduct and community values.
 
 ## Refactoring or reforming the governance committee
 


### PR DESCRIPTION
Fixes #3117. This adds guidance for campaigning for Governance Committee elections. 

cc @open-telemetry/docs-maintainers since this would accept the blog post publication process
cc @avillela @reese-lee @juliafmorgado since this would affect public-facing publications during the elections period.