### PR TITLE
Add self-observability as a core engineering value

### DIFF
--- a/mission-vision-values.md
+++ b/mission-vision-values.md
@@ -90,7 +90,7 @@ OpenTelemetry’s mission and vision describe where we want to go. OpenTelemetry
 engineering values describe how we want to get there.
 
 OpenTelemetry’s core engineering values are _compatibility_, _stability_,
-_resiliency_, and _performance_.
+_resiliency_, _performance_, and _self-observability_.
 
 ### We value _compatibility_
 
@@ -119,6 +119,12 @@ to degrade gracefully as needed.
 OpenTelemetry users should not have to choose between high-quality telemetry and
 a performant application. High performance is a requirement for OpenTelemetry,
 and unexpected interference effects in the host application are unacceptable.
+
+### We value _self-observability_
+
+OpenTelemetry components should be exemplars of well-observed software. We
+instrument our own SDKs, Collector, and tooling, practicing what we preach and
+leading by example.
 
 ## Community values
 


### PR DESCRIPTION
Adds self-observability as a 5th core engineering value, alongside compatibility, stability, resilience, and performance.

The Collector already lists "be an exemplar of observable service" as a [vision goal](https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/vision.md) and has dedicated [observability docs](https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/observability.md) and [internal telemetry guidance](https://opentelemetry.io/docs/collector/internal-telemetry/). On the SDK side, the [specification references](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/self-observability.md) the [SDK self-observability semantic conventions](https://opentelemetry.io/docs/specs/semconv/otel/sdk-metrics/), and multiple SDKs are implementing them ([project board](https://github.com/orgs/open-telemetry/projects/200)). This PR extends the same principle to the project as a whole.

OpenTelemetry's strongest credibility signal is being observable itself. When operators ask "why should I adopt OTel?", the answer should be demonstrable: our own components are instrumented, our own dashboards work, our own conventions have been validated by dogfooding them internally. Making this an explicit engineering value ensures it's treated as a first-class concern across all SIGs, not as an afterthought.
