### PR TITLE
Add Network Semantic Conventions project proposal

### DIFF
--- a/.cspell.yaml
+++ b/.cspell.yaml
@@ -1,6 +1,13 @@
 version: 0.2
 ignorePaths:
-  ["elections/**/*", "tools/github/*", "scripts/**/*.py", "scripts/**/*.sh", "workstreams.yml", "people.yml"]
+  [
+    "elections/**/*",
+    "tools/github/*",
+    "scripts/**/*.py",
+    "scripts/**/*.sh",
+    "workstreams.yml",
+    "people.yml",
+  ]
 # Ignore certain patterns in the workstreams.yml file
 patterns:
   - name: Slack Channel ID
@@ -18,6 +25,7 @@ ignoreRegExpList:
   - GitHub Handle in YML
 words:
   - Abinet
+  - Adell
   - Adriel
   - adrielp
   - agentic
@@ -108,6 +116,7 @@ words:
   - labs
   - Liudmila
   - Mathieu
+  - Matthieu
   - Nale
   - REXX
   - scaphandre
@@ -141,6 +150,7 @@ words:
   - codecov
   - codeowners
   - comms
+  - Cowart
   - credly
   - danielgblanco
   - darren17082
@@ -180,6 +190,7 @@ words:
   - horovits
   - Hrabusa
   - instrgen
+  - ipfix
   - jackjia
   - jaglowski
   - javaagent
@@ -230,18 +241,23 @@ words:
   - npmjs
   - najaryan
   - nakamura
+  - netflow
+  - netflowreceiver
   - neumann
   - neumüller
   - nexis
   - nirga
   - nikimanoledaki
+  - Noirbusson
   - novotny
   - observiq
+  - Ognibene
   - Olly
   - opamp
   - OpenLIT
   - opentelemetry
   - opentelemetrybot
+  - ospf
   - ossf
   - otel
   - otelcol
@@ -271,6 +287,7 @@ words:
   - raesene
   - reiley
   - readmemd
+  - Rexed
   - rollup
   - roadmaps
   - rolldice
@@ -299,6 +316,9 @@ words:
   - sig-localization-zhcn
   - skyscanner
   - sloughter
+  - snmp
+  - snmpreceiver
+  - snmptrapreceiver
   - snyk
   - splk
   - stalnaker
@@ -313,6 +333,7 @@ words:
   - Tigerbeetle
   - Thiru
   - Traceloop
+  - traceroute
   - tarnovski
   - tekton
   - thisthat

--- a/projects/network.md
+++ b/projects/network.md
@@ -1,0 +1,135 @@
+# Network Observability
+
+## Background and description
+
+This project aims to establish unified and comprehensive network semantic conventions for OpenTelemetry, enabling traditional network observability methods (like NetFlow, IPFIX, SNMP) to integrate natively into the ecosystem.
+
+### Current challenges
+
+Currently, OpenTelemetry's network semantic conventions are sparse and predominantly reflect an application's perspective of its own network activity. This creates a significant gap for network-centric observability, which relies heavily on L3 and L4 attributes for protocols like Netflow, SNMP, and SNMP Trap. Compounding this issue is a general lack of defined network-related metrics and traces, including standardized metrics and flow trace instrumentation within OpenTelemetry eBPF Instrumentation (OBI).
+
+On the collection side, the existing OpenTelemetry collector contrib receivers for Netflow and SNMP lack the necessary functionality to be useful and do not adhere to standard network semantic conventions. Furthermore, there is currently no SNMP trap receiver available in the collector contrib.
+
+### Goals, objectives, and requirements
+
+This project makes OpenTelemetry viable for network-centric observability. We will expand core semantic conventions (`network`, `source`, `destination`, `dns`), define standards for traditional telemetry (Netflow, SNMP), and fix fragmented collector receivers. Acting now prevents the spread of non-standard L3/L4 implementations. This work establishes OpenTelemetry as a unified standard for network engineers and provides foundational network telemetry for other SIGs (like OBI and Entities).
+
+- **Expand, clarify, and maintain core network-related semantic conventions**: This includes maintaining the `network`, `source`, `destination`, and `dns` areas. We will work closely with several SIGs, particularly the main Semantic Conventions SIG, as well as the Entities, System, and OBI SIGs.
+
+- **Define deep network semantic conventions for traditional network telemetry methods**: This objective focuses on deep network concepts where we will take advantage of a federated semantic convention repository. Key deliverables include:
+  - Defining Netflow metrics and trace spans
+  - Defining traceroute / network-path telemetry conventions
+  - Defining BGP telemetry conventions
+  - Defining standard SNMP metrics
+  - Defining standard SNMP trap logs
+
+- **Provide support and contributions across the broader OpenTelemetry ecosystem**: Addressing the objectives above establishes the foundation needed to support and contribute across the broader OpenTelemetry ecosystem. Key examples of these separate but related efforts include:
+  - Improving the usability of network-related `opentelemetry-collector-contrib` receiver components (e.g., `snmpreceiver` and `netflowreceiver`) and adding an `snmptrapreceiver`.
+  - Supporting other SIGs (such as OBI) with their network-related telemetry functions.
+  - Defining network-related entity definitions as a part of the Entities SIG.
+
+## Deliverables
+
+**Near-term:**
+
+1. Review existing attributes within `network`, `source`, `destination`, and `dns` areas to clarify language and definitions.
+2. Triage and resolve existing open issues related to labels: [area:network](https://github.com/open-telemetry/semantic-conventions/issues?q=state%3Aopen%20label%3Aarea%3Anetwork), [area:source](https://github.com/open-telemetry/semantic-conventions/issues?q=state%3Aopen%20label%3Aarea%3Asource), [area:destination](https://github.com/open-telemetry/semantic-conventions/issues?q=state%3Aopen%20label%3Aarea%3Adestination), and [area:dns](https://github.com/open-telemetry/semantic-conventions/issues?q=state%3Aopen%20label%3Aarea%3Adns).
+3. Document the [new pattern for source/destination attribute](https://github.com/open-telemetry/semantic-conventions/issues/3791).
+4. Establish a guiding heuristic to dictate what belongs in the `system.network` vs. `network` namespace.
+
+**Mid-term:**
+
+1. Expand core network attributes (DNS, AS, CIDR, and VPC attribution; network interfaces).
+2. Establish protocol-related metrics (e.g., [TCP/UDP proposal](https://github.com/open-telemetry/semantic-conventions/issues/3682), [ICMP issue](https://github.com/open-telemetry/semantic-conventions/issues/1368)).
+3. Define semantic conventions for flow, path, and routing telemetry:
+   - [Netflow metrics](https://github.com/open-telemetry/semantic-conventions/pull/3656) and [netflow trace spans](https://docs.mermin.dev/concepts/introduction-to-flow-traces)
+   - Traceroute / network-path telemetry (hops, hop index, address/hostname/ASN, per-hop RTT, timeouts or unreachable outcomes)
+   - BGP telemetry (ASN, advertised and withdrawn prefixes, route updates, and related metrics/log events)
+4. Establish network-related entities (e.g., network interface, subnet, proc).
+5. Define semantic conventions for common SNMP MIB objects and SNMP Trap events as OpenTelemetry logs.
+
+**Long-term:**
+
+1. Collaborate with the Collector SIG to provide official receivers for Netflow, SNMP, and SNMP Trap.
+2. Collaborate with the OBI SIG to instrument the network, targeting the generation of flow traces and metrics via eBPF.
+3. Define SNMP semantic conventions for less-common and vendor-specific MIBs.
+
+## Staffing / Help Wanted
+
+### SIG
+
+Network
+
+### Required staffing
+
+#### Project Leads(s)
+
+- Rob Cowart (@robcowart) (affiliation: entities)
+- Sven Cowart (@svencowart)  (affiliation: semconv)
+- Antonio Jimenez (@ajimenez1503)
+- Braydon Kains (@braydonk) (affiliation: system)
+
+#### Other Staffing
+
+- Jake Smith (@jksmth)
+- Giuseppe Ognibene (@pinoOgni) (affiliation: obi)
+- Stephen Lang (@skl)
+- Mario Macias (@mariomac) (affiliation: obi)
+- Matthieu Noirbusson (@MatthieuNoirbusson)
+- Henrik Rexed (@henrikrexed)
+- Christian Adell (@chadell)
+
+### Sponsorship
+
+#### TC Sponsor
+
+[TODO: Add TC Sponsor]
+
+#### GC Liaison
+
+Ted Young (@tedsuo)
+
+## Expected Timeline
+
+- **Months 1-2**: Complete near-term deliverables (review core attributes, triage issues, establish namespace heuristics).
+- **Months 3-6**: Complete mid-term deliverables (expand attributes, establish protocol and flow metrics, define entities and SNMP standards).
+- **Months 7-18**: Complete long-term deliverables (collaborate on collector receivers, eBPF instrumentation, and vendor-specific MIBs).
+
+[TODO: After the project has started, please use GitHub project updates to set specific target start and completion dates (see [Project Lifecycle](project-management.md#project-lifecycle) for more information).]
+
+## Labels
+
+- `area:network`
+- `area:source`
+- `area:destination`
+- `area:dns`
+
+---
+
+## Post-Approval Next-Steps
+
+### GitHub Project (Post-Approval)
+
+Once approved, a project should be managed using a [GitHub project](https://docs.github.com/en/issues/planning-and-tracking-with-projects/learning-about-projects/about-projects). This project should be pre-populated with issues that cover all known deliverables, organized by timeline milestones.
+
+Any [member](./guides/contributor/membership.md) associated with the project can create the board.
+Please use the existing [GitHub Project template](https://github.com/orgs/open-telemetry/projects/140) to create your project, replacing placeholders as appropriate.
+
+Once created, the creator of the board should:
+
+- Assign `Admin` privileges on the project to the relevant project members (using a new or existing GitHub team).
+- Change the visibility of the project to `Public` in order to share project status and priorities outside the OpenTelemetry organization (default in template).
+- Configure project workflows to automatically add issues and PRs to the board based on repositories and labels.
+
+See [Project Lifecycle](project-management.md#project-lifecycle) for more information about sharing project updates and status.
+
+Once created, please add a link to the project board here.
+
+### SIG Meetings, Roadmap, and Other Info (Post-Approval)
+
+Once a project is started, its corresponding SIG should meet regularly for discussion. These meeting times should be posted on the [OpenTelemetry public calendar](https://github.com/open-telemetry/community#calendar) and automatically recorded.
+
+Any relevant information related to the SIG (e.g. sponsors, meeting times, Slack channels, meeting notes, etc.) must be publicly available in the [community](https://github.com/open-telemetry/community) SIG tables, which can be updated via the [workstreams.yml](./workstreams.yml) file and running `make generate`.
+Please ensure that the GitHub project ID is added to [workstreams.yml](./workstreams.yml) as a `roadmapProject` resource entry under the corresponding SIG to include this project in the OpenTelemetry Roadmap (see [Roadmap Management](./roadmap-management.md) for more information).
+
+See [How to create and configure meetings](./docs/how-to-handle-public-calendar.md) for updating the public calendar or open an issue in the community repository so it's taken care of.

--- a/projects/network.md
+++ b/projects/network.md
@@ -23,10 +23,13 @@ This project makes OpenTelemetry viable for network-centric observability. We wi
   - Defining standard SNMP metrics
   - Defining standard SNMP trap logs
 
+- **Define and develop network-related entities and attributes**: Focus on network entity domains—Traffic (Application; Tunnel/Encapsulation; Control Plane), Forwarders, Endpoints, Forwarding/Data Plane, and Control Planes—by identifying entities within the 7-layer ISO model (in collaboration with the Entities SIG). Entities are groupings of attributes; work includes identifying core network attributes shared across scenarios, plus attributes required for standard instrumentation through OBI and the network receiver. Inventories will iterate as work progresses (Layer 5–7 entities remain to be identified).
+
+- **Stabilize a core set of network semantic conventions and corresponding instrumentations**: Not every convention will reach stability, but a primary goal is to find a core set of conventions applicable across multiple scenarios and drive those conventions, and the instrumentations that depend on them, to stability. Stabilizing core and instrumentation attributes is also the path to stable entity definitions. Conventions should be defined with the intent to stabilize as soon as confidence is high, to avoid widely adopted unstable conventions.
+
 - **Provide support and contributions across the broader OpenTelemetry ecosystem**: Addressing the objectives above establishes the foundation needed to support and contribute across the broader OpenTelemetry ecosystem. Key examples of these separate but related efforts include:
   - Improving the usability of network-related `opentelemetry-collector-contrib` receiver components (e.g., `snmpreceiver` and `netflowreceiver`) and adding an `snmptrapreceiver`.
   - Supporting other SIGs (such as OBI) with their network-related telemetry functions.
-  - Defining network-related entity definitions as a part of the Entities SIG.
 
 ## Deliverables
 
@@ -45,14 +48,23 @@ This project makes OpenTelemetry viable for network-centric observability. We wi
    - [Netflow metrics](https://github.com/open-telemetry/semantic-conventions/pull/3656) and [netflow trace spans](https://docs.mermin.dev/concepts/introduction-to-flow-traces)
    - Traceroute / network-path telemetry (hops, hop index, address/hostname/ASN, per-hop RTT, timeouts or unreachable outcomes)
    - BGP telemetry (ASN, advertised and withdrawn prefixes, route updates, and related metrics/log events)
-4. Establish network-related entities (e.g., network interface, subnet, proc).
+4. Establish network-related entities and attributes (initial inventory; refine as work progresses):
+   - Focus domains: Traffic (Application; Tunnel/Encapsulation; Control Plane), Forwarders, Endpoints, Forwarding/Data Plane, and Control Planes
+   - Approach entities via the 7-layer ISO model. Starting points:
+     - **Layer 2**: network interface, OSPF interface, 802.1d bridge, 802.1d bridge port, spanning tree
+     - **Layer 3**: IP subnet, BGP, BGP peer, OSPF, OSPF area, OSPF neighbor
+     - **Layer 4**: service access point (SAP — layer-4 network session/socket), TCP, UDP, session, flow
+     - **Layers 5–7**: still to be identified
+   - Identify core network attributes shared across entities and scenarios
+   - Identify instrumentation attributes required by OBI and the network receiver
 5. Define semantic conventions for common SNMP MIB objects and SNMP Trap events as OpenTelemetry logs.
 
 **Long-term:**
 
 1. Collaborate with the Collector SIG to provide official receivers for Netflow, SNMP, and SNMP Trap.
 2. Collaborate with the OBI SIG to instrument the network, targeting the generation of flow traces and metrics via eBPF.
-3. Define SNMP semantic conventions for less-common and vendor-specific MIBs.
+3. Stabilize the core network attribute set and the instrumentation attribute set required by OBI and the network receiver, and drive corresponding entity definitions toward stability.
+4. Define SNMP semantic conventions for less-common and vendor-specific MIBs.
 
 ## Staffing / Help Wanted
 
@@ -67,13 +79,13 @@ Network
 - Rob Cowart (@robcowart) (affiliation: entities)
 - Sven Cowart (@svencowart)  (affiliation: semconv)
 - Antonio Jimenez (@ajimenez1503)
-- Braydon Kains (@braydonk) (affiliation: system)
+- Braydon Kains (@braydonk) (affiliation: system + collectors)
 
 #### Other Staffing
 
 - Jake Smith (@jksmth)
 - Giuseppe Ognibene (@pinoOgni) (affiliation: obi)
-- Stephen Lang (@skl)
+- Stephen Lang (@skl) (affiliation: obi)
 - Mario Macias (@mariomac) (affiliation: obi)
 - Matthieu Noirbusson (@MatthieuNoirbusson)
 - Henrik Rexed (@henrikrexed)
@@ -83,7 +95,7 @@ Network
 
 #### TC Sponsor
 
-[TODO: Add TC Sponsor]
+Liudmila Molkova (@lmolkova)
 
 #### GC Liaison
 
@@ -91,11 +103,11 @@ Ted Young (@tedsuo)
 
 ## Expected Timeline
 
-- **Months 1-2**: Complete near-term deliverables (review core attributes, triage issues, establish namespace heuristics).
-- **Months 3-6**: Complete mid-term deliverables (expand attributes, establish protocol and flow metrics, define entities and SNMP standards).
-- **Months 7-18**: Complete long-term deliverables (collaborate on collector receivers, eBPF instrumentation, and vendor-specific MIBs).
+- **Months 1-2**: Complete near-term deliverables: review core attributes, triage issues, establish namespace heuristics.
+- **Months 3-6**: Complete mid-term deliverables: expand attributes, establish protocol and flow metrics, define entities and SNMP standards.
+- **Months 7-18**: Complete long-term deliverables: collaborate on collector receivers and eBPF instrumentation, stabilize a core set of conventions and corresponding instrumentations/entities once validated, and define vendor-specific MIBs.
 
-[TODO: After the project has started, please use GitHub project updates to set specific target start and completion dates (see [Project Lifecycle](project-management.md#project-lifecycle) for more information).]
+[TODO: After the project has started, please use GitHub project updates to set specific target start and completion dates (see [Project Lifecycle](../project-management.md#project-lifecycle) for more information).]
 
 ## Labels
 
@@ -112,7 +124,7 @@ Ted Young (@tedsuo)
 
 Once approved, a project should be managed using a [GitHub project](https://docs.github.com/en/issues/planning-and-tracking-with-projects/learning-about-projects/about-projects). This project should be pre-populated with issues that cover all known deliverables, organized by timeline milestones.
 
-Any [member](./guides/contributor/membership.md) associated with the project can create the board.
+Any [member](../guides/contributor/membership.md) associated with the project can create the board.
 Please use the existing [GitHub Project template](https://github.com/orgs/open-telemetry/projects/140) to create your project, replacing placeholders as appropriate.
 
 Once created, the creator of the board should:
@@ -121,7 +133,7 @@ Once created, the creator of the board should:
 - Change the visibility of the project to `Public` in order to share project status and priorities outside the OpenTelemetry organization (default in template).
 - Configure project workflows to automatically add issues and PRs to the board based on repositories and labels.
 
-See [Project Lifecycle](project-management.md#project-lifecycle) for more information about sharing project updates and status.
+See [Project Lifecycle](../project-management.md#project-lifecycle) for more information about sharing project updates and status.
 
 Once created, please add a link to the project board here.
 
@@ -129,7 +141,7 @@ Once created, please add a link to the project board here.
 
 Once a project is started, its corresponding SIG should meet regularly for discussion. These meeting times should be posted on the [OpenTelemetry public calendar](https://github.com/open-telemetry/community#calendar) and automatically recorded.
 
-Any relevant information related to the SIG (e.g. sponsors, meeting times, Slack channels, meeting notes, etc.) must be publicly available in the [community](https://github.com/open-telemetry/community) SIG tables, which can be updated via the [workstreams.yml](./workstreams.yml) file and running `make generate`.
-Please ensure that the GitHub project ID is added to [workstreams.yml](./workstreams.yml) as a `roadmapProject` resource entry under the corresponding SIG to include this project in the OpenTelemetry Roadmap (see [Roadmap Management](./roadmap-management.md) for more information).
+Any relevant information related to the SIG (e.g. sponsors, meeting times, Slack channels, meeting notes, etc.) must be publicly available in the [community](https://github.com/open-telemetry/community) SIG tables, which can be updated via the [workstreams.yml](../workstreams.yml) file and running `make generate`.
+Please ensure that the GitHub project ID is added to [workstreams.yml](../workstreams.yml) as a `roadmapProject` resource entry under the corresponding SIG to include this project in the OpenTelemetry Roadmap (see [Roadmap Management](../roadmap-management.md) for more information).
 
-See [How to create and configure meetings](./docs/how-to-handle-public-calendar.md) for updating the public calendar or open an issue in the community repository so it's taken care of.
+See [How to create and configure meetings](../docs/how-to-handle-public-calendar.md) for updating the public calendar or open an issue in the community repository so it's taken care of.


### PR DESCRIPTION
This PR introduces the formal project proposal for Network Telemetry Semantic Conventions.

The goal of this project is to establish unified and comprehensive network semantic conventions for OpenTelemetry, enabling traditional network observability methods (like NetFlow, IPFIX, SNMP) to integrate natively into the ecosystem.

**Key Objectives & Deliverables**
- Core Conventions: Expand, clarify, and maintain the network, source, and destination namespaces.
- Traditional Telemetry: Define deep network semantic conventions for Netflow (metrics and trace spans) and SNMP (metrics and trap logs).
- Ecosystem Integration: Improve the usability of network-related collector receivers (e.g., snmpreceiver, netflowreceiver) and collaborate closely with the Semantic Conventions, Entities, System, and OBI SIGs.