### PR TITLE
chore: update link for langtrace and add exclusion for query

### DIFF
--- a/.lychee.toml
+++ b/.lychee.toml
@@ -35,7 +35,9 @@ exclude = [
     # for performance reasons
     '^https://github.com/open-telemetry/community/(issues|pull)/\d+$',
     'https://gitter.im/open-telemetry/opentelemetry-rust',
-    'https://up-for-grabs.net.*'
+    'https://up-for-grabs.net.*',
+    # GitHub Projects URLs with query params return 400 when accessed without a browser session
+    '^https://github.com/open-telemetry/community/projects\?',
 ]
 
 exclude_path = [

--- a/projects/gen-ai.md
+++ b/projects/gen-ai.md
@@ -7,7 +7,7 @@
 
 Generative AI observability is evolving fast. The industry is still learning how to use GenAI products which creates new opportunities and challenges in the observability space. GenAI observability is focused on development time and verbose telemetry. Non-deterministic nature of GenAI creates the need to measure the quality and safety of responses which become part of observability.
 
-There are multiple GenAI-focused observability projects out there such as [Arize Phoenix](https://arize.com/docs/phoenix), [Langfuse](https://langfuse.com/), [LangSmith](https://www.langchain.com/langsmith), [Langtrace](https://langtrace.ai/), [OpenLit](https://github.com/openlit/openlit), [Traceloop](https://www.traceloop.com/docs/introduction) and many others.
+There are multiple GenAI-focused observability projects out there such as [Arize Phoenix](https://arize.com/docs/phoenix), [Langfuse](https://langfuse.com/), [LangSmith](https://www.langchain.com/langsmith), [Langtrace](https://docs.langtrace.ai/), [OpenLit](https://github.com/openlit/openlit), [Traceloop](https://www.traceloop.com/docs/introduction) and many others.
 
 Some of these projects are based on OpenTelemetry, others are "inspired by" it, but don't have out-of-the-box integration with OTel.
 


### PR DESCRIPTION
The existing link is returning 404 and causing error on CI. Update to a valid link.

GitHub Projects URLs with query params return 400 when accessed without a browser session