### PR TITLE
Add semantic-conventions-conformance repo to semconv general SIG

### DIFF
--- a/sigs.md
+++ b/sigs.md
@@ -42,7 +42,7 @@ This page contains detailed information for all OpenTelemetry Special Interest G
 - **Meeting notes:** [Google Doc](https://docs.google.com/document/d/10xG7DNKWRhxNmFGt3yYd3980a9uwS8lMl2LvQL3VNK8)
 - **Meeting invites group:** [calendar-semconv](https://groups.google.com/a/opentelemetry.io/g/calendar-semconv)
 - **Slack channel:** [#otel-semantic-conventions](https://cloud-native.slack.com/archives/C041APFBYQP)
-- **Repositories:** [open-telemetry/semantic-conventions](https://github.com/open-telemetry/semantic-conventions)
+- **Repositories:** [open-telemetry/semantic-conventions](https://github.com/open-telemetry/semantic-conventions), [open-telemetry/semantic-conventions-conformance](https://github.com/open-telemetry/semantic-conventions-conformance)
 - **Technical Committee sponsors:** [Armin Ruech](https://github.com/arminru) (leading), [Liudmila Molkova](https://github.com/lmolkova) (leading)
 - **Governance Committee liaison:** [Trask Stalnaker](https://github.com/trask)
 

--- a/workstreams.yml
+++ b/workstreams.yml
@@ -104,6 +104,7 @@
       name: '#otel-semantic-conventions'
       id: C041APFBYQP
   - repository: open-telemetry/semantic-conventions
+  - repository: open-telemetry/semantic-conventions-conformance
 - id: semconv-system-metrics
   kind: sig
   sigCategory: specification


### PR DESCRIPTION
Adds the newly created `open-telemetry/semantic-conventions-conformance` repository to the Semantic Conventions: General SIG in `workstreams.yml`, and regenerates `sigs.md`.

Related to #3605