### PR TITLE
add saved replies templates

### DIFF
--- a/docs/how-to-use-saved-replies.md
+++ b/docs/how-to-use-saved-replies.md
@@ -1,0 +1,60 @@
+# How to use saved replies on GitHub
+
+Saved replies let maintainers and approvers respond to common situations
+(policy violations, contribution guidance, closing stale PRs, etc.) without
+retyping the same message every time. This document explains how to set them
+up on GitHub and links to the prepared reply templates the OpenTelemetry
+community maintains.
+
+## Setting up saved replies
+
+Saved replies live on your **personal GitHub account**; they are not tied to
+an organization or repository. Any saved reply you create is available to you
+across every repo you comment on.
+
+1. Go to [github.com/settings/replies](https://github.com/settings/replies).
+2. Click **Add a saved reply**.
+3. Give it a short, descriptive **title** (this is what you will search for
+   later — e.g. `genai-policy-violation`).
+4. Paste the reply body from one of the templates in [replies/](./replies/).
+5. Click **Add saved reply**.
+
+Repeat for each template you want available.
+
+## Using a saved reply
+
+When commenting on an issue or pull request:
+
+1. Click the reply comment box.
+2. Click the arrow icon in the toolbar above the text area (**Insert a reply**),
+   or press <kbd>Ctrl</kbd>+<kbd>.</kbd> (Windows/Linux) or <kbd>⌘</kbd>+<kbd>.</kbd>
+   (macOS).
+3. Search for the reply by title and select it.
+4. Adjust the text as needed for the specific situation if necessary.
+5. Post the comment.
+
+## Guidelines for using prepared replies
+
+- **Read the contribution first.** A saved reply is a time-saver, not a
+  substitute for reviewing what the contributor submitted.
+- **Be respectful.** These replies exist to keep responses consistent and
+  fair. Follow the
+  [Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md).
+
+## Available templates
+
+Prepared reply templates live in [replies/](./replies/). Each file contains
+the body of one saved reply plus a short note on when to use it.
+
+- [code-of-conduct-violation.md](./replies/code-of-conduct-violation.md) —
+  Comment or behavior violates the [Code of Conduct](../code-of-conduct.md).
+- [genai-policy-violation.md](./replies/genai-policy-violation.md) — PR
+  appears to violate the [Generative AI Contribution Policy](../policies/genai.md)
+  and will be closed.
+
+## Adding a new template
+
+If you find yourself writing the same response repeatedly, add a new file
+under [replies/](./replies/) and open a PR. Keep the template short, link to
+the relevant policy, and include a short note at the top of the file
+describing when to use it.

--- a/docs/how-to-use-saved-replies.md
+++ b/docs/how-to-use-saved-replies.md
@@ -51,6 +51,8 @@ the body of one saved reply plus a short note on when to use it.
 - [genai-policy-violation.md](./replies/genai-policy-violation.md) — PR
   appears to violate the [Generative AI Contribution Policy](../policies/genai.md)
   and will be closed.
+- [needs-repro.md](./replies/needs-repro.md) — Issue lacks actionable detail;
+  ask the reporter for a minimal reproducible example.
 
 ## Adding a new template
 

--- a/docs/replies/code-of-conduct-violation.md
+++ b/docs/replies/code-of-conduct-violation.md
@@ -1,0 +1,40 @@
+# Reply: Code of Conduct violation
+
+**When to use:** A comment, review, issue, or pull request contains language
+or behavior that violates the
+[OpenTelemetry Code of Conduct](../../code-of-conduct.md) or the underlying
+[CNCF Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md)
+— for example personal attacks, harassment, discriminatory language, or
+sustained disrespectful behavior.
+
+Before using this reply:
+
+- Consider whether editing or hiding the offending comment is appropriate.
+- For serious or repeated violations, report to the Governance Committee at
+  `governance-committee@opentelemetry.io`. Do not rely on a public
+  reply alone.
+- If you are unsure whether the behavior crosses the line, escalate to
+  another maintainer or a GC member before responding publicly.
+
+---
+
+## Reply body
+
+> Please note that this comment is not in line with the OpenTelemetry
+> [Code of Conduct](https://github.com/open-telemetry/community/blob/main/code-of-conduct.md),
+> which we expect all participants in this project to follow.
+>
+> OpenTelemetry aims to be a welcoming place where members feel safe to
+> respectfully share their opinions and disagreements. Personal attacks,
+> harassment, and disrespectful behavior are not acceptable here, regardless
+> of the technical disagreement behind them.
+>
+> Please review the Code of Conduct and adjust your tone going forward.
+> Continued violations can result in further action, up to and including
+> removal from the project.
+>
+> If you have experienced or witnessed behavior that makes this community
+> less welcoming, you can report it to the Governance Committee at
+> `governance-committee@opentelemetry.io`. See the
+> [Code of Conduct](https://github.com/open-telemetry/community/blob/main/code-of-conduct.md)
+> for reporting options, including anonymous reporting.

--- a/docs/replies/genai-policy-violation.md
+++ b/docs/replies/genai-policy-violation.md
@@ -1,0 +1,30 @@
+# Reply: Generative AI policy violation — closing PR
+
+**When to use:** A pull request appears to be generated primarily by an LLM
+without the contributor's own review, understanding, or engagement and you
+are closing it.
+
+Before using this reply, make sure you have read the contribution and are
+confident it violates the policy. If you are unsure, ask the contributor to
+clarify their process instead of closing.
+
+---
+
+## Reply body
+
+> Thanks for opening this pull request. Unfortunately, this contribution
+> appears to have been generated primarily by a generative AI tool without
+> sufficient human review or engagement, which is not in line with our
+> [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
+>
+> Maintainer time is limited, and we rely on contributors to be active,
+> willing participants in the contribution process, understanding the code
+> they submit, being able to discuss and iterate on it, and ensuring it fits
+> the current state of the project. LLM output alone does not meet that bar.
+>
+> I'm closing this PR for now. You are very welcome to come back with a
+> contribution you have driven and reviewed yourself. Using an LLM as an
+> assistant is fine, and disclosing that use (for example on the PR description)
+> is encouraged. Please review the policy linked above before opening a new PR.
+>
+> Thanks for your understanding.

--- a/docs/replies/needs-repro.md
+++ b/docs/replies/needs-repro.md
@@ -1,0 +1,18 @@
+# Reply: Issue needs a minimal reproducible example
+
+**When to use:** An issue does not include enough detail for a maintainer to
+investigate — no reproduction steps, no versions, no code, or only a vague
+description of the symptom. Use this to ask the reporter for a minimal
+reproducible example before spending time on the issue.
+
+Consider adding a label such as `needs-repro` or `needs-info` after posting
+so the issue is easy to find and can be closed later if the reporter does not
+respond.
+
+---
+
+## Reply body
+
+> Please provide a [minimal reproducible example](https://stackoverflow.com/help/minimal-reproducible-example)
+> as a public GitHub repository that demonstrates the issue you're
+> experiencing, so we can look into this further.


### PR DESCRIPTION
Provide guidance on common cases that need a reply.

Unfortunately, this is not possible to do org wise (https://github.com/orgs/community/discussions/4974), so providing the templates so people can add to their own account.